### PR TITLE
Changed fixed/default value of depth and time window in tememetryWebs…

### DIFF
--- a/extensions-core/src/main/java/org/thingsboard/server/extensions/core/plugin/telemetry/handlers/TelemetryWebsocketMsgHandler.java
+++ b/extensions-core/src/main/java/org/thingsboard/server/extensions/core/plugin/telemetry/handlers/TelemetryWebsocketMsgHandler.java
@@ -301,9 +301,9 @@ public class TelemetryWebsocketMsgHandler extends DefaultWebsocketMsgHandler {
                     ctx.loadLatestTimeseries(entityId, keys, new PluginCallback<List<TsKvEntry>>() {
                         @Override
                         public void onSuccess(PluginContext ctx, List<TsKvEntry> data) {
-                            log.debug("Latest TsKvEntry [{}]", data);
+                            log.info("Latest TsKvEntry [{}]", data);
                             long endTs = data.get(0).getTs();
-                            long startTs = endTs - 61000;
+                            long startTs = endTs - cmd.getTimeWindow();
                             List<TsKvQuery> queries = keys.stream().map(key -> new BaseTsKvQuery(key, startTs, endTs, cmd.getInterval(), getLimit(cmd.getLimit()), getAggregation(cmd.getAgg()))).collect(Collectors.toList());
                             ctx.loadTimeseries(entityId, queries, new PluginCallback<List<TsKvEntry>>() {
                                 @Override
@@ -355,7 +355,7 @@ public class TelemetryWebsocketMsgHandler extends DefaultWebsocketMsgHandler {
                             log.info("Latest DsKvEntry [{}]", data);
                             Double endDs = data.get(0).getDs();
                             log.info("endDs = " + endDs);
-                            Double startDs = endDs - 3000.0;
+                            Double startDs = endDs - cmd.getDepthWindow();
                             List<DsKvQuery> queries = keys.stream().map(key -> new BaseDsKvQuery(key, startDs, endDs, cmd.getInterval(), getLimit(cmd.getLimit()), getDepthAggregation(cmd.getAgg()))).collect(Collectors.toList());
                             ctx.loadDepthSeries(entityId, queries, new PluginCallback<List<DsKvEntry>>() {
                                 @Override


### PR DESCRIPTION
1. When there is no real time data coming to thingsboard then the graphs display data which is latest minus a fixed range. This range is of one minute for timeseries data and of 3000 feet for depthseries data.

2. This range is now been changed to the time window and depth window configured through UI.    