### PR TITLE
Docs Enhancements

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,6 +14,9 @@ help:
 
 .PHONY: help Makefile
 
+auto:
+	sphinx-autobuild $(SOURCEDIR) $(BUILDDIR)
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/docs/_static/wider-content.css
+++ b/docs/_static/wider-content.css
@@ -1,0 +1,3 @@
+.wy-nav-content {
+max-width: 1200px !important;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,6 +96,9 @@ html_static_path = ['_static']
 #
 # html_sidebars = {}
 
+# apply css widening of the too-narrow read-the-docs content section
+def setup(app):
+    app.add_stylesheet('wider-content.css')
 
 # -- Options for HTMLHelp output ---------------------------------------------
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,34 +1,23 @@
 # Getting Started
+Tempus uses Sphinx to manage its documentation. The actual format of the documentation is [ReStructured Text](http://docutils.sourceforge.net/docs/user/rst/quickref.html)
 
-
-Tempus uses Sphinx to manage its documentation. The acutal format of the documentation is [ReStructured Text](http://docutils.sourceforge.net/docs/user/rst/quickref.html)
 ## Pre-requisites
-
 You need at least Python 2.7 to get started
 
-## Sphinx installation
-
-To get Sphinx use pip:
-
-```bash
-pip install sphinx sphinx-autobuild
-```
-
-The HTML output also makes use of [sphinx-tabs](https://github.com/djungelorm/sphinx-tabs). To install this execute:
+## Installation
+If this is your first time using these docs, install dependencies from the `requirements.txt` with pip using the following command:
 
 ```bash
-pip install sphinx_tabs
+pip install -r ./requirements.txt
 ```
 
-We are also using sphinx_rtd_theme hence to install that execute: 
-
-
-```bash
-pip install sphinx_rtd_theme
-```
-
+## Building
 In order to make the HTML version, from the root of the /docs folder, execute: 
-
 ```bash
 make html
+```
+
+To make html continuously while developing documentation, execute:
+```bash
+make auto
 ```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+sphinx 
+sphinx-autobuild
+sphinx_tabs
+sphinx_rtd_theme


### PR DESCRIPTION
This PR include:
- Makefile support for sphinx auto building
- Requirements.txt support for installing all python requirements in one pip command
- docs Readme modification with simple instructions
- CSS 'hack' to widen contents of the read-the-docs sphinx html theme