### PR TITLE
Tempus elaboration 37

### DIFF
--- a/ui/src/app/app.js
+++ b/ui/src/app/app.js
@@ -78,6 +78,7 @@ import tempusClusterInfo from './api/cluster-info.service';
 import tempusApiComputation from './api/computation.service';
 import tempusApiComputationJob from './api/computation-job.service';
 import tempusTempusboard from './tempusboard';
+import tempusDataModels from './data_models';
 import tempusApplications from './applications';
 import tempusApiAuditLog from './api/audit-log.service';
 
@@ -147,6 +148,7 @@ angular.module('tempus', [
     tempusApiComputation,
     tempusApiComputationJob,
     tempusTempusboard,
+    tempusDataModels,
     tempusApplications,
     tempusApiAuditLog,
     uiRouter])

--- a/ui/src/app/data_models/data_models.controller.js
+++ b/ui/src/app/data_models/data_models.controller.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017-2018 Hashmap, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-disable import/no-unresolved, import/default, no-unused-vars */
+import './data_models.scss';
+
+/*@ngInject*/
+export function DataModelsController($scope, $log, $state, $stateParams, userService, deviceService, types, attributeService, $q, dashboardService, applicationService, entityService, tempusboardService, utils, $filter, dashboardUtils) {
+	var vm = this;
+}

--- a/ui/src/app/data_models/data_models.directive.js
+++ b/ui/src/app/data_models/data_models.directive.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017-2018 Hashmap, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*@ngInject*/
+export default function DataModelsDirective() {
+    var linker = function () {
+
+    }
+    return {
+        restrict: "E",
+        link: linker,
+        scope: {
+        }
+    };
+}

--- a/ui/src/app/data_models/data_models.routes.js
+++ b/ui/src/app/data_models/data_models.routes.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017-2018 Hashmap, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-disable import/no-unresolved, import/default */
+
+import dataModelsTemplate from './data_models.tpl.html';
+
+/* eslint-enable import/no-unresolved, import/default */
+
+/*@ngInject*/
+export default function DataModelsRoutes($stateProvider, types) {
+    $stateProvider
+        .state('home.data_models', {
+            url: '/data_models',
+            params: {'topIndex': 0},
+            module: 'private',
+            auth: ['TENANT_ADMIN', 'CUSTOMER_USER'],
+            views: {
+                "content@home": {
+                    templateUrl: dataModelsTemplate,
+                    controller: 'DataModelsController',
+                    controllerAs: 'vm'
+                }
+            },
+            data: {
+                alertsType: 'tenant',
+                searchEnabled: true,
+                searchByEntitySubtype: true,
+                searchEntityType: types.entityType.alert,
+                pageTitle: 'data_model.data_models'
+            },
+            ncyBreadcrumb: {
+                label: '{"icon": "data_models", "label": "data_model.data_models", "link": "/static/svg/data-models-icon.svg"}'
+            }
+        });
+
+}

--- a/ui/src/app/data_models/data_models.scss
+++ b/ui/src/app/data_models/data_models.scss
@@ -1,0 +1,15 @@
+/**
+ * Copyright © 2017-2018 Hashmap, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/ui/src/app/data_models/data_models.tpl.html
+++ b/ui/src/app/data_models/data_models.tpl.html
@@ -19,3 +19,30 @@
 	<div layout="row" class="row" style="width:100%; clear:both;">
 	</div>
 </section>
+<section layout="row" layout-wrap class="tb-footer-buttons md-fab" layout-align="start end">
+	<md-fab-speed-dial ng-disabled="$root.loading" ng-show="true" md-open=""
+	 class="md-scale" md-direction="up">
+		<md-fab-trigger>
+			<md-button ng-disabled="$root.loading" class="tb-btn-footer md-accent md-hue-2 md-fab" aria-label="{{ 'add data model'}}">
+				<md-tooltip md-direction="top">
+					{{ "add data model"}}
+				</md-tooltip>
+				<ng-md-icon icon="add"></ng-md-icon>
+			</md-button>
+		</md-fab-trigger>
+		<md-fab-actions>
+			<md-button ng-disabled="$root.loading" class="tmd-accent md-hue-2 md-fab" ng-click="" aria-label="{{ 'action.create' | translate }}">
+				<md-tooltip md-direction="top">
+					{{ "create new data model" }}
+				</md-tooltip>
+				<ng-md-icon icon="insert_drive_file"></ng-md-icon>
+			</md-button>
+			<md-button ng-disabled="$root.loading" class="tmd-accent md-hue-2 md-fab" ng-click="" aria-label="{{ 'action.import' | translate }}">
+				<md-tooltip md-direction="top">
+					{{ "import data model" }}
+				</md-tooltip>
+				<ng-md-icon icon="file_upload"></ng-md-icon>
+			</md-button>
+		</md-fab-actions>
+	</md-fab-speed-dial>
+</section>

--- a/ui/src/app/data_models/data_models.tpl.html
+++ b/ui/src/app/data_models/data_models.tpl.html
@@ -1,0 +1,21 @@
+<!--
+
+    Copyright © 2017-2018 Hashmap, Inc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<section layout="row" class="ng-scope layout-row" layout-wrap>
+	<div layout="row" class="row" style="width:100%; clear:both;">
+	</div>
+</section>

--- a/ui/src/app/data_models/index.js
+++ b/ui/src/app/data_models/index.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2017-2018 Hashmap, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import '../dashboard/dashboard.scss';
+
+import uiRouter from 'angular-ui-router';
+import tempusGrid from '../components/grid.directive';
+import tempusApiUser from '../api/user.service';
+import tempusApiDevice from '../api/device.service';
+import tempusApiCustomer from '../api/customer.service';
+import tempusApiDashboard from '../api/dashboard.service';
+import tempusApiWidget from '../api/widget.service';
+import tempusApiTempusboard from '../api/tempusboard.service';
+import tempusWidgetConfig from '../components/widget/widget-config.directive';
+import dashboardStates from '../dashboard/states';
+
+
+import DataModelsRoutes from './data_models.routes';
+import {DataModelsController} from './data_models.controller';
+
+export default angular.module('tempus.data_models', [
+    uiRouter,
+    tempusGrid,
+    tempusApiUser,
+    tempusApiDevice,
+    tempusApiCustomer,
+    tempusApiDashboard,
+    tempusApiWidget,
+    tempusApiTempusboard,
+    tempusWidgetConfig,
+    dashboardStates
+])
+    .config(DataModelsRoutes)
+    .controller('DataModelsController', DataModelsController)
+    .name;


### PR DESCRIPTION
This PR includes:
- addition of the `ui/src/app/data_models` directory with html, scss, and javascript to power the data_models UI.
- Functionality that allows the user to go to the data_models page and see an empty workspace with a nonfunctioning `add` button.
- modification of the main JS app to include the `tempusDataModel` angular module

This closes tempus-elaboration-37