### PR TITLE
Added DataModel Angular service for interacting with backend

### DIFF
--- a/ui/src/app/api/datamodel.service.js
+++ b/ui/src/app/api/datamodel.service.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2017-2018 Hashmap, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import angularStorage from 'angular-storage';
+
+export default angular.module('tempus.api.datamodel', [
+    angularStorage])
+    .factory('datamodelService', DatamodelService)
+    .name;
+
+/*@ngInject*/
+function DatamodelService($http, $q, $rootScope, adminService, dashboardService, toast, store) {
+
+
+    var service = {
+        setDataModelData:setDataModelData,
+        clearDataModelData:clearDataModelData,
+        getDataModelData:getDataModelData,
+        saveDataModel:saveDataModel,
+        listDataModel:listDataModel
+
+    }
+
+    return service;
+
+    function setDataModelData(dataModel) {
+        store.set('data_model', dataModel);
+        //var data = getDataModelData();
+
+    }
+
+    function clearDataModelData() {
+        store.remove('data_model');
+    }
+
+    function getDataModelData() {
+        return store.get('data_model');
+    }
+
+    function saveDataModel(dataModeldata) {
+        var deferred = $q.defer();
+        var url = '/api/data-model';
+        $http.post(url, dataModeldata).then(function success(response) {
+            deferred.resolve(response.data);
+        }, function fail(response) {
+            deferred.reject(response.data);
+        });
+        return deferred.promise;
+    }
+
+    function listDataModel() {
+        var deferred = $q.defer();
+        var url = '/api/';
+        $http.get(url).then(function success(response) {
+            deferred.resolve(response.data);
+        }, function fail(response) {
+            deferred.reject(response.data);
+        });
+        return deferred.promise;
+
+
+    }
+
+
+}

--- a/ui/src/app/data_models/data_models.controller.js
+++ b/ui/src/app/data_models/data_models.controller.js
@@ -18,7 +18,7 @@ import './data_models.scss';
 import addDataModel from './add-datamodel.tpl.html';
 
 /*@ngInject*/
-export function AddDataModelController($scope, $mdDialog, saveItemFunction, helpLinks, $log) {
+export function AddDataModelController($scope, $mdDialog, saveItemFunction, helpLinks) {
 
     var vm = this;
     vm.helpLinks = helpLinks;
@@ -32,6 +32,7 @@ export function AddDataModelController($scope, $mdDialog, saveItemFunction, help
     }
 
     function add() {
+
         saveItemFunction(vm.item).then(function success(item) {
             vm.item = item;
             $scope.theForm.$setPristine();
@@ -42,14 +43,15 @@ export function AddDataModelController($scope, $mdDialog, saveItemFunction, help
 
 
 /*@ngInject*/
-export function DataModelsController($scope, $log, $rootScope, $state, $stateParams, userService, deviceService, types, attributeService, $q, dashboardService, applicationService, entityService, tempusboardService, utils, $filter, dashboardUtils, $mdDialog, $document, $translate) {
-	var vm = this;
-    //vm.save = save;
+export function DataModelsController($scope, $rootScope, $state, $stateParams, userService, datamodelService, deviceService, types, attributeService, $q, dashboardService, applicationService, entityService, tempusboardService, utils, $filter, dashboardUtils, $mdDialog, $document, $translate) {
+
+    var vm = this;
 
     vm.openDataModelDialog = openDataModelDialog;
     vm.cancel = cancel;
     vm.saveDataModelFunc = saveDataModelFunc;
     vm.AddDataModelController = AddDataModelController;
+    vm.listDataModel = listDataModel;
 
 
     function openDataModelDialog($event) {
@@ -68,13 +70,31 @@ export function DataModelsController($scope, $log, $rootScope, $state, $statePar
     }
 
 
-    function saveDataModelFunc(dataModel) { $log.log(dataModel);
+    function saveDataModelFunc(item) {
+
         var deferred = $q.defer();
+        datamodelService.saveDataModel(item).then(function success(response) {
+            deferred.resolve(response.data);
+        }, function fail(response) {
+            deferred.reject(response.data);
+        });
         return deferred.promise;
+
     }
 
     function cancel() {
         $mdDialog.cancel();
+    }
+
+    function listDataModel() {
+
+        var deferred = $q.defer();
+        datamodelService.listDataModel().then(function success(response) {
+            deferred.resolve(response.data);
+        }, function fail(response) {
+            deferred.reject(response.data);
+        });
+        return deferred.promise;
     }
 
 }

--- a/ui/src/app/data_models/datamodel-fieldset.tpl.html
+++ b/ui/src/app/data_models/datamodel-fieldset.tpl.html
@@ -25,7 +25,7 @@
             </div>
         </md-input-container>
         <md-input-container class="md-block">
-            <tb-json-form form-control="theForm">
+            <tb-json-form form-control="theForm" model="dataModel">
             </tb-json-form>
         </md-input-container>
         <md-input-container class="md-block">

--- a/ui/src/app/data_models/index.js
+++ b/ui/src/app/data_models/index.js
@@ -18,6 +18,7 @@ import '../dashboard/dashboard.scss';
 import uiRouter from 'angular-ui-router';
 import tempusGrid from '../components/grid.directive';
 import tempusApiUser from '../api/user.service';
+import tempusApiDatamodel from '../api/datamodel.service';
 import tempusApiDevice from '../api/device.service';
 import tempusApiCustomer from '../api/customer.service';
 import tempusApiDashboard from '../api/dashboard.service';
@@ -39,6 +40,7 @@ export default angular.module('tempus.data_models', [
     tempusApiDevice,
     tempusApiCustomer,
     tempusApiDashboard,
+    tempusApiDatamodel,
     tempusApiWidget,
     tempusApiTempusboard,
     tempusWidgetConfig,


### PR DESCRIPTION
This PR includes Datamodel service implementation for interacting with back end.Created a new file datamodel.service.js , also created basic skeleton and functions for saving and listing datamodels from the database once canvas is created. 