### PR TITLE
Tempus-570 - datamodel object deletion

### DIFF
--- a/application/src/main/java/com/hashmapinc/server/controller/DataModelController.java
+++ b/application/src/main/java/com/hashmapinc/server/controller/DataModelController.java
@@ -129,4 +129,17 @@ public class DataModelController extends BaseController {
             throw handleException(e);
         }
     }
+
+    @PreAuthorize("hasAnyAuthority('TENANT_ADMIN', 'CUSTOMER_USER')")
+    @DeleteMapping(value = "/data-model/objects/{objectId}")
+    @ResponseBody
+    public Boolean removeDatamodelObjectById(@PathVariable("objectId") String objectId) throws TempusException {
+        try {
+            checkParameter("objectId", objectId);
+            dataModelObjectService.removeById(new DataModelObjectId(toUUID(objectId)));
+            return true;
+        } catch (Exception e) {
+            throw handleException(e);
+        }
+    }
 }

--- a/dao/src/main/java/com/hashmapinc/server/dao/datamodel/DataModelObjectService.java
+++ b/dao/src/main/java/com/hashmapinc/server/dao/datamodel/DataModelObjectService.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 public interface DataModelObjectService {
     DataModelObject save(DataModelObject dataModelObject);
+    void removeById(DataModelObjectId dataModelObjectId);
     DataModelObject findById(DataModelObjectId dataModelObjectId);
     List<DataModelObject> findByDataModelId(DataModelId dataModelId);
 }

--- a/dao/src/main/java/com/hashmapinc/server/dao/datamodel/DataModelObjectServiceImp.java
+++ b/dao/src/main/java/com/hashmapinc/server/dao/datamodel/DataModelObjectServiceImp.java
@@ -91,6 +91,12 @@ public class DataModelObjectServiceImp implements DataModelObjectService {
         return dataModelObjects;
     }
 
+    @Override
+    public void removeById(DataModelObjectId dataModelObjectId) {
+        validateId(dataModelObjectId, INCORRECT_DATA_MODEL_OBJECT_ID + dataModelObjectId);
+        dataModelObjectDao.removeById(dataModelObjectId.getId());
+    }
+
     private DataValidator<DataModelObject> dataModelObjectDataValidator =
             new DataValidator<DataModelObject>() {
                 @Override

--- a/ui/src/app/api/datamodel.service.js
+++ b/ui/src/app/api/datamodel.service.js
@@ -28,7 +28,8 @@ function DatamodelService($http, $q) {
         getDatamodelObjects:    getDatamodelObjects,
         saveDatamodel:          saveDatamodel,
         saveDatamodelObject:    saveDatamodelObject,
-        listDatamodels:         listDatamodels
+        listDatamodels:         listDatamodels,
+        deleteDatamodelObject:  deleteDatamodelObject
     }
 
     // loads the datamodel objects for the datamodel with ID = datamodelID
@@ -62,7 +63,7 @@ function DatamodelService($http, $q) {
      */
     function saveDatamodelObject(datamodelObject, datamodelID) {
         var deferred = $q.defer();
-        var url = '/api/data-model/' + datamodelID + '/objects';
+        var url = '/api/data-model/' + datamodelID + '/objects/' + datamodelObject.id;
         $http.post(url, datamodelObject).then(function success(response) {
             deferred.resolve(response);
         }, function fail(response) {
@@ -91,6 +92,21 @@ function DatamodelService($http, $q) {
             deferred.resolve(response.data);
         }, function fail(response) {
             deferred.reject(response.data);
+        });
+        return deferred.promise;
+    }
+
+    /**
+     *  deletes a datamodel object in the backend
+     *  @param dmObjectId - ID of the datamodel object to delete
+     */
+    function deleteDatamodelObject(dmObjectId) {
+        var deferred = $q.defer();
+        var url = '/api/data-model/objects/' + dmObjectId;
+        $http.delete(url).then(function success(response) {
+            deferred.resolve(response);
+        }, function fail(response) {
+            deferred.reject(response);
         });
         return deferred.promise;
     }

--- a/ui/src/app/api/datamodel.service.js
+++ b/ui/src/app/api/datamodel.service.js
@@ -63,7 +63,7 @@ function DatamodelService($http, $q) {
      */
     function saveDatamodelObject(datamodelObject, datamodelID) {
         var deferred = $q.defer();
-        var url = '/api/data-model/' + datamodelID + '/objects/' + datamodelObject.id;
+        var url = '/api/data-model/' + datamodelID + '/objects';
         $http.post(url, datamodelObject).then(function success(response) {
             deferred.resolve(response);
         }, function fail(response) {

--- a/ui/src/app/data_models/data_model.controller.js
+++ b/ui/src/app/data_models/data_model.controller.js
@@ -139,9 +139,9 @@ export function DataModelController($log, $mdDialog, $document, $stateParams, $t
             name: vm.datamodelTitle
         };
         datamodelService.saveDatamodel(datamodelToSave).then(function success(response) {
-            $log.debug("successfully saved datamodel..." + response);
+            $log.debug("successfully saved datamodel..." + angular.toJson(response));
         }, function fail(response) {
-            $log.error("could not save datamodel..." + response);
+            $log.error("could not save datamodel..." + angular.toJson(response));
         });
 
         // save the datamodel objects
@@ -171,9 +171,9 @@ export function DataModelController($log, $mdDialog, $document, $stateParams, $t
 
             // save the datamodel object
             datamodelService.saveDatamodelObject(toSave, $stateParams.datamodelId).then(function success(response) {
-                $log.debug("successfully saved datamodel object..." + response);
+                $log.debug("successfully saved datamodel object..." + angular.toJson(response));
             }, function fail(response) {
-                $log.error("could not save datamodel object..." + response);
+                $log.error("could not save datamodel object..." + angular.toJson(response));
             });
         });
     }
@@ -199,7 +199,7 @@ export function DataModelController($log, $mdDialog, $document, $stateParams, $t
         // load datamodel objects
         datamodelService.getDatamodelObjects($stateParams.datamodelId).
         then(function success(data) {
-            $log.info("successfully loaded datamodel objects:" + data);
+            $log.info("successfully loaded datamodel objects:" + angular.toJson(data));
             
             // process the objects
             var datamodelObjects = [];  // array of processed dm objects
@@ -420,7 +420,7 @@ export function DataModelController($log, $mdDialog, $document, $stateParams, $t
                 { "name": vm.stepperData.name },
                 $stateParams.datamodelId
             ).then(function success(response) {
-                $log.debug("successfully created datamodel object..." + response);
+                $log.debug("successfully created datamodel object..." + angular.toJson(response));
 
                 // parse the response into a datamodelObject 
                 var dmo = createDatamodelObject(
@@ -449,29 +449,39 @@ export function DataModelController($log, $mdDialog, $document, $stateParams, $t
                 // hide the stepper and reset its state
                 vm.cancel();
             }, function fail(response) {
-                $log.error("could not create datamodel object..." + response);
+                $log.error("could not create datamodel object..." + angular.toJson(response));
             });
         }
     };
 
     // delete the object and reload the datamodel
     vm.onStepperDelete = function () {
-        $log.debug("deleting data model object...");
+        // confirm delete
+        var confirm = $mdDialog.confirm()
+            .title('Delete Object')
+            .htmlContent("Are you sure you want to delete this object?")
+            .cancel("Cancel")
+            .ok("Submit");
+        $mdDialog.show(confirm).then(function () {
+            $log.debug("deleting data model object...");
 
-        // delete the object by ID
-        datamodelService.deleteDatamodelObject(
-            vm.stepperData.id
-        ).then(function success(response) {
-            $log.debug("successfully deleted datamodel object..." + response);
+            // delete the object by ID
+            datamodelService.deleteDatamodelObject(
+                vm.stepperData.id
+            ).then(function success(response) {
+                $log.debug("successfully deleted datamodel object..." + angular.toJson(response));
 
-            // hide the stepper and reset its state
-            vm.cancel();
+                // hide the stepper and reset its state
+                vm.cancel();
 
-            // reload the datamodel
-            loadDatamodel();
-        }, function fail(response) {
-            $log.error("could not create datamodel object..." + response);
+                // reload the datamodel
+                loadDatamodel();
+            }, function fail(response) {
+                $log.error("could not create datamodel object..." + angular.toJson(response));
+            });
+        }, function () {
         });
+        
     };
 
     // add a datamodel object attribute to the stepper's current data

--- a/ui/src/app/data_models/datamodel-object-stepper.tpl.html
+++ b/ui/src/app/data_models/datamodel-object-stepper.tpl.html
@@ -124,6 +124,9 @@
 
     <md-dialog-actions layout="row">
       <span flex></span>
+      <md-button ng-click="vm.onStepperDelete()" style="margin-right:20px;" ng-if="vm.stepperMode === 'EDIT'" id="stepperDelete" class="md-warn md-raised">
+        Delete
+      </md-button>
       <md-button ng-click="vm.stepperState = vm.stepperState - 1" ng-if="vm.stepperState > 0" id="stepperBack">
         Back
       </md-button>

--- a/ui/src/app/device/device.controller.js
+++ b/ui/src/app/device/device.controller.js
@@ -452,13 +452,13 @@ export function DeviceController($rootScope,userService, deviceService, customer
             .cancel($translate.instant('action.no'))
             .ok($translate.instant('action.yes'));
         $mdDialog.show(confirm).then(function () {
-                vm.deviceGridConfig.deleteItemFunc(item.id.id).then(function success() {
-                    $scope.resetFilter();
+            vm.deviceGridConfig.deleteItemFunc(item.id.id).then(function success() {
+                $scope.resetFilter();
 
-                });
-            },
-            function () {
             });
+        },
+        function () {
+        });
     }
 
     $scope.addDevice = function($event) {


### PR DESCRIPTION
This PR includes:
- addition of a `DELETE` endpoint for the datamodel object API
- addition of a delete method in the datamodel angular service
- UI enhancement for users to be able to delete datamodel objects in the object editing `md-dialog`

This PR connects to #570 