### PR TITLE
Tempus-571 - datamodel editing change acceptance / rejection support

### DIFF
--- a/ui/src/app/data_models/datamodel-object-stepper.tpl.html
+++ b/ui/src/app/data_models/datamodel-object-stepper.tpl.html
@@ -87,9 +87,9 @@
           <md-content class="md-padding">
             <md-input-container class="md-block" ng-keypress="$event.keyCode === 13 && vm.onStepperEnter();">
               <label>Parent</label>
-              <md-select name="tempusType" ng-model="vm.stepperData.parent" ng-init="nodes = vm.nodes.get()">
+              <md-select name="tempusType" ng-model="vm.stepperData.parent_node_id" ng-init="nodes = vm.nodes.get()">
                 <md-option ng-value="null">None</md-option>
-                <md-option ng-repeat="node in nodes" ng-value="node.datamodelObject">{{node.label}}</md-option>
+                <md-option ng-repeat="node in nodes" ng-value="node.id">{{node.label}}</md-option>
               </md-select>
             </md-input-container>
           </md-content>

--- a/ui/src/app/data_models/datamodel-object-stepper.tpl.html
+++ b/ui/src/app/data_models/datamodel-object-stepper.tpl.html
@@ -115,7 +115,7 @@
 
             <md-subheader class="md-no-sticky">Relationships</md-subheader>
             <md-list-item>
-              <p>Parent: {{vm.stepperData.parent ? vm.stepperData.parent.name : "None"}}</p>
+              <p>Parent: {{vm.stepperData.parent_node_id ? vm.nodes.get(vm.stepperData.parent_node_id).label : "--"}}</p>
             </md-list-item>
           </md-content>
         </md-tab>


### PR DESCRIPTION
This PR includes:
- a full shift to nodes array, edges array client side datamodel object model
- logic for supporting change acceptance and rejection for the create/delete object user experience

This connects to #571 