### PR TITLE
Tempus-803-Duplicate attribute name datamodel object's attribute

### DIFF
--- a/ui/src/app/data_models/data_model.controller.js
+++ b/ui/src/app/data_models/data_model.controller.js
@@ -398,6 +398,8 @@ export function DataModelController($scope, $mdDialog, $document, $stateParams, 
 
         // reset stepper state
         resetStepperState();
+        vm.attrName = [];
+
 
         // load datamodel object into stepper data if one is being edited
         if (nodeToEdit) {
@@ -408,6 +410,7 @@ export function DataModelController($scope, $mdDialog, $document, $stateParams, 
 
             // set stepper mode
             vm.stepperMode = "EDIT"
+
 
             // process the object into stepper data
             var dmo = nodeToEdit.datamodelObject;
@@ -420,6 +423,9 @@ export function DataModelController($scope, $mdDialog, $document, $stateParams, 
             vm.stepperData.logoFile = dmo.logoFile;
             vm.stepperState = 3; // go straight to review page
 
+            for (var i = 0; i < dmo.attributes.length; i++) {
+                vm.attrName.push(dmo.attributes[i].toLowerCase().trim());
+            }
             // get the parent ID if it exists
             let edge = vm.edges.get().filter(e => {
                 return e.to === nodeToEdit.id;
@@ -430,10 +436,9 @@ export function DataModelController($scope, $mdDialog, $document, $stateParams, 
 
         } else {
             // create a new node id for a new object creation stepper
-            vm.stepperData.node_id = vm.nodes.length + 1;
-        }
+           vm.stepperData.node_id = vm.nodes.length + 1;
 
-        // show the mdDialog
+        }
         $mdDialog.show({
             controller: function () { return vm }, // use the current controller (this) as the mdDialog controller
             controllerAs: 'vm',
@@ -597,10 +602,17 @@ export function DataModelController($scope, $mdDialog, $document, $stateParams, 
     // add a datamodel object attribute to the stepper's current data
     vm.addDatamodelObjectAttribute = function () {
         // add the attribute if it exists
-        if (vm.stepperData.currentAttribute) {
-            vm.stepperData.attributes.push(vm.stepperData.currentAttribute);
+        var inArray = vm.attrName.indexOf(angular.lowercase(vm.stepperData.currentAttribute.trim()));
+        if(inArray !== -1) {
+            vm.stepperState = 1;
+            vm.stepperMode = "";
+            toast.showError($translate.instant('dataModels.duplicateAttribute'));
+            return false;
         }
-        // reset the current attribute
+        if (vm.stepperData.currentAttribute) {
+           vm.stepperData.attributes.push(vm.stepperData.currentAttribute.trim());
+           vm.attrName.push(angular.lowercase(vm.stepperData.currentAttribute.trim()));
+        }
         vm.stepperData.currentAttribute = "";
     };
 
@@ -628,8 +640,10 @@ export function DataModelController($scope, $mdDialog, $document, $stateParams, 
     vm.updateAttribute =  function (attributeName, index){
         $scope.editing = false;
         vm.stepperData.attributes[index] = attributeName;
+        vm.attrName[index] = angular.lowercase(attributeName.trim());
     }
     vm.deleteAttribute =  function (index){
         vm.stepperData.attributes.splice(index, 1);
+        vm.attrName.splice(index,1);
     }
 }

--- a/ui/src/app/locale/locale.constant.js
+++ b/ui/src/app/locale/locale.constant.js
@@ -624,7 +624,8 @@ export default angular.module('tempus.locale', [])
                     "relationships":"Relationships",
                     "image":"Icon",
                     "parent":"Parent",
-                    "noAttribute":"No Attributes"
+                    "noAttribute":"No Attributes",
+                    "duplicateAttribute":"Attribute already created, please use different name."
                 },
                 "datakey": {
                     "settings": "Settings",


### PR DESCRIPTION
This PR contains code for resolving the issue of having duplicate datamodel object's attribute name

In order to streamline the review of the contribution please
ensure the following steps have been taken:

### For all changes:
- [x] Is there a Waffle ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with Tempus-XXXX where XXXX is the waffle number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically dev)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn clean install at the root Tempus folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] Have you added documentation for any UI or API related changes to the /docs folder

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
