### PR TITLE
Tempus-835-Added code for selecting multiple childs for datamodel object

### DIFF
--- a/ui/src/app/data_models/data_model.controller.js
+++ b/ui/src/app/data_models/data_model.controller.js
@@ -22,527 +22,615 @@ import objectInformation from './object_info.tpl.html';
 
 /*@ngInject*/
 export function DataModelController($scope, $mdDialog, $document, $stateParams, $timeout, $q, datamodelService, toast, $translate) {
-    //=============================================================================
-    // Main
-    //=============================================================================
-    // create the controller
+	//=============================================================================
+	// Main
+	//=============================================================================
+	// create the controller
 	var vm = this;
-    vm.isEdit = false; // keeps track of whether the model is being edited
+	vm.isEdit = false; // keeps track of whether the model is being edited
 
-    // create the stepper
-    vm.stepperState = 0;        // keeps track of the current stepper step
-    vm.stepperMode = "";        // keeps track of the current stepper mode ("CREATE" or "EDIT")
-    vm.stepperData = {};        // keeps track of the in-progress data model object and is bound to the stepper
-    resetStepperState();        // instantiate the stepper model and structure the stepperData object
+	// create the stepper
+	vm.stepperState = 0; // keeps track of the current stepper step
+	vm.stepperMode = ""; // keeps track of the current stepper mode ("CREATE" or "EDIT")
+	vm.stepperData = {}; // keeps track of the in-progress data model object and is bound to the stepper
+	resetStepperState(); // instantiate the stepper model and structure the stepperData object
 
-    // manage persistence states
-    var objectDeleteList = [];  // list of datamodel object ID's to delete when changes are confirmed
-    var objectDeleteNameList = [];
-    vm.fileAdded = fileAdded;
-    vm.clearFile = clearFile;
-    vm.getNodes = getNodes;
-    vm.dataModelName =[];
-    vm.dataModelSavedName = [];
-    $scope.editing = false;
+	// manage persistence states
+	var objectDeleteList = []; // list of datamodel object ID's to delete when changes are confirmed
+	var objectDeleteNameList = [];
+	vm.fileAdded = fileAdded;
+	vm.clearFile = clearFile;
+	vm.getNodes = getNodes;
+	vm.dataModelName = [];
+	vm.dataModelSavedName = [];
+	$scope.editing = false;
 
 
-    // Create the graph that will be plotted
-    vm.nodes = new vis.DataSet();
-    vm.edges = new vis.DataSet();
-    var network_data = {
-        nodes: vm.nodes,
-        edges: vm.edges
-    };
-    var network_options = {
-        layout: {
-            hierarchical: {
-                enabled: true,
-                nodeSpacing: 100,
-                direction: "UD",
-                sortMethod: "directed"
-            }
-        },
-        groups: {
-            Device: {
-                shape: 'icon',
-                icon: {
-                    face: 'FontAwesome',
-                    code: '\uf1b2',
-                    size: 50,
-                    color: '#607D8B'
-                }
-            },
-            Asset: {
-                shape: 'icon',
-                icon: {
-                    face: 'FontAwesome',
-                    code: '\uf1b3',
-                    size: 50,
-                    color: '#FF5722'
-                }
-            }
-        }
-    };
+	// Create the graph that will be plotted
+	vm.nodes = new vis.DataSet();
+	vm.edges = new vis.DataSet();
+	var network_data = {
+		nodes: vm.nodes,
+		edges: vm.edges
+	};
+	var network_options = {
+		layout: {
+			hierarchical: {
+				enabled: true,
+				nodeSpacing: 100,
+				direction: "UD",
+				sortMethod: "directed"
+			}
+		},
+		groups: {
+			Device: {
+				shape: 'icon',
+				icon: {
+					face: 'FontAwesome',
+					code: '\uf1b2',
+					size: 50,
+					color: '#607D8B'
+				}
+			},
+			Asset: {
+				shape: 'icon',
+				icon: {
+					face: 'FontAwesome',
+					code: '\uf1b3',
+					size: 50,
+					color: '#FF5722'
+				}
+			}
+		}
+	};
 
-    // build the vis network and add assign event listeners
-    var networkContainer = angular.element("#dataModelViewerContainer")[0];
-    var network = new vis.Network(networkContainer, network_data, network_options);
-    network.on('selectNode', onDatamodelObjectSelect);
+	// build the vis network and add assign event listeners
+	var networkContainer = angular.element("#dataModelViewerContainer")[0];
+	var network = new vis.Network(networkContainer, network_data, network_options);
+	network.on('selectNode', onDatamodelObjectSelect);
 
-    // load the datamodel
-    loadDatamodel();
-    //=============================================================================
+	// load the datamodel
+	loadDatamodel();
+	//=============================================================================
 
-    // toggle between edit mode and view mode
-    vm.toggleDMEditMode = function () {
-        vm.isEdit = !vm.isEdit;
-    };
+	// toggle between edit mode and view mode
+	vm.toggleDMEditMode = function () {
+		vm.isEdit = !vm.isEdit;
+	};
 
-    // reset the stepper state and clear its current form data
-    function resetStepperState() {
-        vm.stepperState = 0;    // keeps track of the current stepper step (0-3)
-        vm.stepperMode = "";    // either CREATE or EDIT. Usefull for hiding/showing the delete option
-        vm.stepperData = {      // keeps track of the in-progress data model object and is bound to the stepper
-            id: null,           // datamodel object id
-            node_id: null,      // visjs node id
-            name: "",
-            desc: "",
-            type: "",
-            parent_node_id: null,   // visjs node id of the parent
-            currentAttribute: "",
-            attributes: []
-        }
-    }
+	// reset the stepper state and clear its current form data
+	function resetStepperState() {
+		vm.stepperState = 0; // keeps track of the current stepper step (0-3)
+		vm.stepperMode = ""; // either CREATE or EDIT. Usefull for hiding/showing the delete option
+		vm.stepperData = { // keeps track of the in-progress data model object and is bound to the stepper
+			id: null, // datamodel object id
+			node_id: null, // visjs node id
+			name: "",
+			desc: "",
+			type: "",
+			parent_node_id: null, // visjs node id of the parent
+			currentAttribute: "",
+			attributes: []
+		}
+	}
 
-    // structure for a datamodel object
-    function createDatamodelObject(id, name, desc, obj_type, attributes, logoFile) {
-        return {
-            id: id,
-            name: name,
-            desc: desc,
-            type: obj_type,
-            attributes: attributes,
-            logoFile:logoFile
-        }
-    }
+	// structure for a datamodel object
+	function createDatamodelObject(id, name, desc, obj_type, attributes, logoFile) {
+		return {
+			id: id,
+			name: name,
+			desc: desc,
+			type: obj_type,
+			attributes: attributes,
+			logoFile: logoFile
+		}
+	}
 
-    // close the stepper and reset its state
-    vm.cancel = function () {
-        // hide the dialog
-        $mdDialog.hide();
+	// close the stepper and reset its state
+	vm.cancel = function () {
+		// hide the dialog
+		$mdDialog.hide();
 
-        // reset the stepper
-        resetStepperState();
-    };
+		// reset the stepper
+		resetStepperState();
+	};
 
-     function getNodes() {
-         var new_nodes = vm.nodes.get();
-         if(vm.stepperData.id !== null && vm.stepperData.parent_node_id !== null) {
-             new_nodes = new_nodes.filter(node => {
-                    return vm.stepperData.id !== node.datamodelObject.id;
-              });
-         } else {
-             new_nodes = new_nodes.filter(node => {
-                    return vm.stepperData.name !== node.label;
-              });
-         }
-         return new_nodes;
-     }
-    //=============================================================================
-    // Datamodel functionality
-    //=============================================================================
-    // save the datamodel and datamodel objects
-    function saveDatamodel() {
-        // save the datamodel
-        var datamodelToSave = {
-            id: {
-                id: $stateParams.datamodelId,
-                entityType: "DATA_MODEL"
-            },
-            name: vm.datamodelTitle,
-            additionalInfo:vm.additionalInfo
+	function getNodes() {
+		var new_nodes = vm.nodes.get();
+		if (vm.stepperData.id !== null && vm.stepperData.parent_node_id !== null) {
+			new_nodes = new_nodes.filter(node => {
+				return vm.stepperData.id !== node.datamodelObject.id;
+			});
+		} else {
+			new_nodes = new_nodes.filter(node => {
+				return vm.stepperData.name !== node.label;
+			});
+		}
+		return new_nodes;
+	}
 
-        };
-        datamodelService.saveDatamodel(datamodelToSave);
-        var new_nodes = vm.nodes.get().filter(node => {
-            return !node.datamodelObject.id; // true if id does not exist
-        });
 
-        // create an array of promises for each create call
-        var promises = new_nodes.map(node => {  // return promises for each node
-            // get ID's
+	//=============================================================================
+	// Datamodel functionality
+	//=============================================================================
+	// save the datamodel and datamodel objects
+	function saveDatamodel() {
+		// save the datamodel
+		var datamodelToSave = {
+			id: {
+				id: $stateParams.datamodelId,
+				entityType: "DATA_MODEL"
+			},
+			name: vm.datamodelTitle,
+			additionalInfo: vm.additionalInfo
 
-            return datamodelService.saveDatamodelObject(
-                { "name": node.datamodelObject.name }, // name doesn't matter now, just need the ID
-                $stateParams.datamodelId
-            );
-        });
+		};
+		datamodelService.saveDatamodel(datamodelToSave);
+		var new_nodes = vm.nodes.get().filter(node => {
+			return !node.datamodelObject.id; // true if id does not exist
+		});
 
-        // once all promises resolve, we'll have enough IDs to save the model
-       // vm.dataModelName =[];
-        $q.all(promises).then(function success(response) {
+		// create an array of promises for each create call
+		var promises = new_nodes.map(node => { // return promises for each node
+			// get ID's
 
-            // save the new id in the new nodes
-            response.forEach(r => {
-                let node = new_nodes.pop();
-                node.datamodelObject.id = r.data.id.id;
-                vm.nodes.update(node);
-            });
+			return datamodelService.saveDatamodelObject({
+					"name": node.datamodelObject.name
+				}, // name doesn't matter now, just need the ID
+				$stateParams.datamodelId
+			);
+		});
 
-            // create a map from each dmo ID to it's parent dmo ID
-            var parentMap = {};
-            vm.edges.forEach(edge => {
-                let child_id = vm.nodes.get(edge.to).datamodelObject.id;
-                let parent_id = vm.nodes.get(edge.from).datamodelObject.id;
-                parentMap[child_id] = parent_id;
-            });
+		// once all promises resolve, we'll have enough IDs to save the model
+		// vm.dataModelName =[];
+		$q.all(promises).then(function success(response) {
 
-            // save the datamodel objects
-            vm.nodes.forEach(node => {
-                // get the datamodel object associated with this node
-                let dmo = node.datamodelObject;
+			// save the new id in the new nodes
+			response.forEach(r => {
+				let node = new_nodes.pop();
+				node.datamodelObject.id = r.data.id.id;
+				vm.nodes.update(node);
+			});
 
-                // create the saveable object
-                let toSave = {};
-                toSave.dataModelId = { id: $stateParams.datamodelId, entityType: "DATA_MODEL" };
-                toSave.id = { id: dmo.id, entityType: "DATA_MODEL_OBJECT" };
-                toSave.description = dmo.desc;
-                toSave.name = dmo.name;
-                toSave.type = dmo.type;
-                toSave.logoFile = dmo.logoFile;
-                if (parentMap[dmo.id]) { // get parent dmo ID, if it exists
-                    toSave.parentId = { id: parentMap[dmo.id], entityType: "DATA_MODEL_OBJECT" };
-                }
-                if (dmo.attributes) { // get attributes, if any
-                    toSave.attributeDefinitions = dmo.attributes.map(attr => {
-                        return {
-                            "dataModelObjectId": toSave.id,
-                            "name": attr,
-                            "valueType": "STRING"
-                        }
-                    });
-                }
-                // save the datamodel object
-                datamodelService.saveDatamodelObject(toSave, $stateParams.datamodelId).then(function success(response) {
-                    vm.dataModelSavedName.push(response.data.name);
-                });
-            });
-        });
-    }
+			// create a map from each dmo ID to it's parent dmo ID
+			var parentMap = {};
+			vm.edges.forEach(edge => {
+				let child_id = vm.nodes.get(edge.to).datamodelObject.id;
+				let parent_id = vm.nodes.get(edge.from).datamodelObject.id;
+				parentMap[child_id] = parent_id;
+			});
 
-    /**
-     * load the data model
-     */
-    function loadDatamodel() {
-        // erase current plot
-        vm.nodes.clear();
-        vm.edges.clear();
+			// save the datamodel objects
+			vm.nodes.forEach(node => {
+				// get the datamodel object associated with this node
+				let dmo = node.datamodelObject;
 
-        // reset data persistence state
-        objectDeleteList = [];
-        objectDeleteNameList = [];
-        datamodelService.getDatamodel($stateParams.datamodelId).
-        then(function success(data) {
-            vm.datamodelTitle = data.name;
-            vm.additionalInfo = data.additionalInfo;
-        });
+				// create the saveable object
+				let toSave = {};
+				toSave.dataModelId = {
+					id: $stateParams.datamodelId,
+					entityType: "DATA_MODEL"
+				};
+				toSave.id = {
+					id: dmo.id,
+					entityType: "DATA_MODEL_OBJECT"
+				};
+				toSave.description = dmo.desc;
+				toSave.name = dmo.name;
+				toSave.type = dmo.type;
+				toSave.logoFile = dmo.logoFile;
+				if (parentMap[dmo.id]) { // get parent dmo ID, if it exists
+					toSave.parentId = {
+						id: parentMap[dmo.id],
+						entityType: "DATA_MODEL_OBJECT"
+					};
+				}
+				if (dmo.attributes) { // get attributes, if any
+					toSave.attributeDefinitions = dmo.attributes.map(attr => {
+						return {
+							"dataModelObjectId": toSave.id,
+							"name": attr,
+							"valueType": "STRING"
+						}
+					});
+				}
+				// save the datamodel object
+				datamodelService.saveDatamodelObject(toSave, $stateParams.datamodelId).then(function success(response) {
+					vm.dataModelSavedName.push(response.data.name);
+				});
+			});
+		});
+	}
 
-        // load datamodel objects
-        datamodelService.getDatamodelObjects($stateParams.datamodelId).
-        then(function success(data) {
+	/**
+	 * load the data model
+	 */
+	function loadDatamodel() {
+		// erase current plot
+		vm.nodes.clear();
+		vm.edges.clear();
 
-            // process the nodes, gather the raw edges
-            var dmo_to_node = {}    // hashmap of dmo id strings -> visjs node ids
-            var edges = [];         // array of {to: child_dmo_id, from: parent_dmo_id} edges
-            var currId = 1;         // keeps track of current node id
-            data.forEach(dmo => {   // iterate and process each object
-                // get attributes
-                var attributes = dmo.attributeDefinitions.map(attribute => {
-                    return attribute.name;
-                });
+		// reset data persistence state
+		objectDeleteList = [];
+		objectDeleteNameList = [];
+		datamodelService.getDatamodel($stateParams.datamodelId).
+		then(function success(data) {
+			vm.datamodelTitle = data.name;
+			vm.additionalInfo = data.additionalInfo;
+		});
 
-                // add edge if parent exists
-                if (dmo.parentId) {
-                    edges.push({ to: dmo.id.id, from: dmo.parentId.id});
-                }
+		// load datamodel objects
+		datamodelService.getDatamodelObjects($stateParams.datamodelId).
+		then(function success(data) {
 
-                var logoFile = dmo.logoFile ? dmo.logoFile : null;
-                // create node
-                var node = {
-                    id:     currId++,
-                    label:  dmo.name,
-                    group:  dmo.type,
-                    datamodelObject: createDatamodelObject(
-                        dmo.id.id,
-                        dmo.name,
-                        dmo.description,
-                        dmo.type,
-                        attributes,
-                        logoFile
-                    )
-                };
+			// process the nodes, gather the raw edges
+			var dmo_to_node = {} // hashmap of dmo id strings -> visjs node ids
+			var edges = []; // array of {to: child_dmo_id, from: parent_dmo_id} edges
+			var currId = 1; // keeps track of current node id
+			data.forEach(dmo => { // iterate and process each object
+				// get attributes
+				var attributes = dmo.attributeDefinitions.map(attribute => {
+					return attribute.name;
+				});
 
-                // store id in hashmap
-                dmo_to_node[dmo.id.id] = node.id;
-                vm.dataModelSavedName.push(angular.lowercase(dmo.name));
+				// add edge if parent exists
+				if (dmo.parentId) {
+					edges.push({
+						to: dmo.id.id,
+						from: dmo.parentId.id
+					});
+				}
 
-                // add the node to the nodes set
-                vm.nodes.add(node);
-            });
+				var logoFile = dmo.logoFile ? dmo.logoFile : null;
+				// create node
+				var node = {
+					id: currId++,
+					label: dmo.name,
+					group: dmo.type,
+					datamodelObject: createDatamodelObject(
+						dmo.id.id,
+						dmo.name,
+						dmo.description,
+						dmo.type,
+						attributes,
+						logoFile
+					)
+				};
 
-            // process the raw edges
-            currId = 1; // reuse this counter for keeping track of current edge id
-            edges.forEach(edge => {
-                vm.edges.add({
-                    id:     currId++,
-                    to:     dmo_to_node[edge.to],
-                    from:   dmo_to_node[edge.from]
-                });
-            });
+				// store id in hashmap
+				dmo_to_node[dmo.id.id] = node.id;
+				vm.dataModelSavedName.push(angular.lowercase(dmo.name));
 
-            plotDatamodel();
+				// add the node to the nodes set
+				vm.nodes.add(node);
+			});
 
-        });
-    }
+			// process the raw edges
+			currId = 1; // reuse this counter for keeping track of current edge id
+			edges.forEach(edge => {
+				vm.edges.add({
+					id: currId++,
+					to: dmo_to_node[edge.to],
+					from: dmo_to_node[edge.from]
+				});
+			});
 
-    /**
-     * plot the datamodel
-     */
-    function plotDatamodel() {
-        // center the view after the drawing is finished
-        network.once('afterDrawing', function (params) {
-            // focus the camera on the new nodes
-            network.fit({
-                nodes: vm.nodes.getIds(),
-                animation: true
-            });
-        });
+			plotDatamodel();
 
-        // turn off physics after the graph is finished settling
-        network.once('stabilized', function (params) {
-            network.setOptions({ nodes: { physics: false } });
-        });
-    }
+		});
+	}
 
-    function fileAdded($file) {
-        var reader = new FileReader();
-        reader.onload = function(event) {
-            $scope.$apply(function() {
-                if(event.target.result) {
-                    var addedFile = event.target.result;
-                    if (addedFile && addedFile.length > 0) {
-                        if($file.getExtension() === 'png' || $file.getExtension() === 'jpeg' || $file.getExtension() === 'svg' || $file.getExtension() === 'jpg'){
-                            vm.stepperData.logoFile = addedFile;
-                            vm.stepperData.logoFileName = $file.name;
-                        }
+	/**
+	 * plot the datamodel
+	 */
+	function plotDatamodel() {
+		// center the view after the drawing is finished
+		network.once('afterDrawing', function (params) {
+			// focus the camera on the new nodes
+			network.fit({
+				nodes: vm.nodes.getIds(),
+				animation: true
+			});
+		});
+
+		// turn off physics after the graph is finished settling
+		network.once('stabilized', function (params) {
+			network.setOptions({
+				nodes: {
+					physics: false
+				}
+			});
+		});
+	}
+
+	function fileAdded($file) {
+		var reader = new FileReader();
+		reader.onload = function (event) {
+			$scope.$apply(function () {
+				if (event.target.result) {
+					var addedFile = event.target.result;
+					if (addedFile && addedFile.length > 0) {
+						if ($file.getExtension() === 'png' || $file.getExtension() === 'jpeg' || $file.getExtension() === 'svg' || $file.getExtension() === 'jpg') {
+							vm.stepperData.logoFile = addedFile;
+							vm.stepperData.logoFileName = $file.name;
+						}
+					}
+				}
+			});
+		};
+		reader.readAsDataURL($file.file);
+	}
+
+	function clearFile() {
+		// $scope.theForm.$setDirty();
+		vm.stepperData.logoFile = null;
+		vm.stepperData.logoFileName = null;
+	}
+
+	// handle the selection of a visjs node
+	function onDatamodelObjectSelect(properties) {
+		// immediately deselect everything
+		network.unselectAll();
+
+		// get the node thvar at was selected
+		var nodeId = properties.nodes[0];
+		var node = vm.nodes.get(nodeId);
+		vm.nodeValue = node;
+		vm.childNode =[];
+		vm.childName = '';
+
+		let edge = vm.edges.get().filter(e => {
+			return e.to === node.id;
+		}).pop();
+		if (edge) {
+			vm.nodeValue.datamodelObject.parent_id = edge.from;
+		}
+		if (vm.nodeValue.datamodelObject.parent_id) {
+			var parentNode = vm.nodes.get(vm.nodeValue.datamodelObject.parent_id);
+			vm.nodeValue.datamodelObject.parent = parentNode.datamodelObject.name;
+
+		}
+				angular.forEach(vm.edges.get(), function (value, key) {
+      if(node.id == value.from) {
+
+var childNodeVal = vm.nodes.get(value.to);
+                       vm.childNode.push(childNodeVal.datamodelObject.name);
                     }
-                }
-            });
-        };
-        reader.readAsDataURL($file.file);
-    }
-
-    function clearFile() {
-       // $scope.theForm.$setDirty();
-        vm.stepperData.logoFile = null;
-        vm.stepperData.logoFileName = null;
-    }
-
-    // handle the selection of a visjs node
-    function onDatamodelObjectSelect(properties) {
-        // immediately deselect everything
-        network.unselectAll();
-
-        // get the node that was selected
-        var nodeId = properties.nodes[0];
-        var node = vm.nodes.get(nodeId);
-        vm.nodeValue = node;
-
-        let edge = vm.edges.get().filter(e => {
-                return e.to === node.id;
-          }).pop();
-          if (edge) {
-                vm.nodeValue.datamodelObject.parent_id = edge.from;
-         }
 
 
-        if(vm.nodeValue.datamodelObject.parent_id) {
-            var parentNode = vm.nodes.get(vm.nodeValue.datamodelObject.parent_id);
-            vm.nodeValue.datamodelObject.parent = parentNode.datamodelObject.name;
+					// add edge to edges
+				});
+				if(vm.childNode.length > 0) {vm.childName = vm.childNode.join(',')}
 
-         }
+		if (vm.isEdit) {
+			vm.showDatamodelObjectStepper(null, node);
+		} else {
+			$timeout(function () {
+				$mdDialog.show({
+					controller: function () {
+						return vm
+					}, // use the current controller (this) as the mdDialog controller
+					controllerAs: 'vm',
+					templateUrl: objectInformation,
+					parent: angular.element($document[0].body),
+					fullscreen: true,
+					targetEvent: nodeId
+				});
+			}, 0);
 
-        if (vm.isEdit) {
-            vm.showDatamodelObjectStepper(null, node);
-        } else {
-            $timeout( function(){
-               $mdDialog.show({
-                    controller: function () { return vm }, // use the current controller (this) as the mdDialog controller
-                    controllerAs: 'vm',
-                    templateUrl: objectInformation,
-                    parent: angular.element($document[0].body),
-                    fullscreen: true,
-                    targetEvent: nodeId
-                });
-         }  , 0 );
+		}
+	}
+	/**
+	 * start the mdDialog for adding a datamodel object
+	 *
+	 * @param targetEvent - event, if any, that triggered this show
+	 * @param nodeToEdit - visjs node to edit if a node is being edited, otherwise null for new node
+	 */
+	vm.showDatamodelObjectStepper = function (targetEvent, nodeToEdit) {
 
-        }
-    }
-    /**
-     * start the mdDialog for adding a datamodel object
-     *
-     * @param targetEvent - event, if any, that triggered this show
-     * @param nodeToEdit - visjs node to edit if a node is being edited, otherwise null for new node
-     */
-    vm.showDatamodelObjectStepper = function (targetEvent, nodeToEdit) {
-
-        // reset stepper state
-        resetStepperState();
-        vm.attrName = [];
-
-
-        // load datamodel object into stepper data if one is being edited
-        if (nodeToEdit) {
-            // sanity check
-            if(!nodeToEdit.datamodelObject) {
-                return;
-            }
-
-            // set stepper mode
-            vm.stepperMode = "EDIT"
+		// reset stepper state
+		resetStepperState();
+		vm.attrName = [];
+		var child_nodes = [];
 
 
-            // process the object into stepper data
-            var dmo = nodeToEdit.datamodelObject;
-            vm.stepperData.id = dmo.id;
-            vm.stepperData.node_id = nodeToEdit.id;
-            vm.stepperData.name = dmo.name;
-            vm.stepperData.desc = dmo.desc;
-            vm.stepperData.type = dmo.type;
-            vm.stepperData.attributes = dmo.attributes;
-            vm.stepperData.logoFile = dmo.logoFile;
-            vm.stepperState = 3; // go straight to review page
+		// load datamodel object into stepper data if one is being edited
+		if (nodeToEdit) {
+			// sanity check
+			if (!nodeToEdit.datamodelObject) {
+				return;
+			}
 
-            for (var i = 0; i < dmo.attributes.length; i++) {
-                vm.attrName.push(dmo.attributes[i].toLowerCase().trim());
-            }
-            // get the parent ID if it exists
-            let edge = vm.edges.get().filter(e => {
-                return e.to === nodeToEdit.id;
-            }).pop();
-            if (edge) {
-                vm.stepperData.parent_node_id = edge.from;
-            }
+			// set stepper mode
+			vm.stepperMode = "EDIT"
 
-        } else {
-            // create a new node id for a new object creation stepper
-           vm.stepperData.node_id = vm.nodes.length + 1;
 
-        }
-        $mdDialog.show({
-            controller: function () { return vm }, // use the current controller (this) as the mdDialog controller
-            controllerAs: 'vm',
-            templateUrl: objectStepper,
-            parent: angular.element($document[0].body),
-            fullscreen: true,
-            targetEvent: targetEvent
-        });
-    };
+			// process the object into stepper data
+			var dmo = nodeToEdit.datamodelObject;
+			vm.stepperData.id = dmo.id;
+			vm.stepperData.node_id = nodeToEdit.id;
+			vm.stepperData.name = dmo.name;
+			vm.stepperData.desc = dmo.desc;
+			vm.stepperData.type = dmo.type;
+			vm.stepperData.attributes = dmo.attributes;
+			vm.stepperData.logoFile = dmo.logoFile;
+			vm.stepperState = 3; // go straight to review page
 
-    // listen for datamodel stepper enter keypresses
-    vm.onStepperEnter = function() {
-        $timeout(function() {
-            // handle object info tab
-            if (vm.stepperState === 0) {
-                angular.element('#stepperNext').click();
-               // handle attributes tab
-            } else if (vm.stepperState === 1) {
-                vm.stepperData.currentAttribute.length === 0 ? angular.element('#stepperNext').click() : angular.element('#stepperAddAttrButton').click();
+			for (var i = 0; i < dmo.attributes.length; i++) {
+				vm.attrName.push(dmo.attributes[i].toLowerCase().trim());
+			}
+			// get the parent ID if it exists
+			let edge = vm.edges.get().filter(e => {
+				return e.to === nodeToEdit.id;
+			}).pop();
+			if (edge) {
+				vm.stepperData.parent_node_id = edge.from;
+			}
+				angular.forEach(vm.edges.get(), function (value, key) {
+                 if(nodeToEdit.id == value.from) {
+                       child_nodes.push(value.to);
+                    }
 
-                // handle relationships tab
-            } else if (vm.stepperState === 2) {
-                angular.element('#stepperNext').click();
 
-                // handle review tab
-            } else if (vm.stepperState === 3) {
-                angular.element('#stepperSubmit').click();
-            }
-        });
-    }
+					// add edge to edges
+				});
 
-    // process new and edited objects from a stepper submit click
-    vm.onStepperSubmit = function() {
-        // create the data model object to be submitted
-        var dmo = createDatamodelObject(
-            vm.stepperData.id,
-            vm.stepperData.name.trim(),
-            vm.stepperData.desc,
-            vm.stepperData.type,
-            vm.stepperData.attributes,
-            vm.stepperData.logoFile
-        );
+				if(child_nodes.length > 0){vm.stepperData.child_node_id = child_nodes;}
 
-        // get the nodeId and the node (if it exists)
-        var nodeId = vm.stepperData.node_id;
-        var node = vm.nodes.get(nodeId); // this is null if no node exists with this id
-        if(node == null) {
-            if(vm.dataModelName.indexOf(angular.lowercase(vm.stepperData.name.trim())) !== -1) {
-                vm.stepperState = 0;    // keeps track of the current stepper step (0-3)
-                vm.stepperMode = "";    // either CREATE or EDIT. Usefull for hiding/showing the delete option
-                toast.showError($translate.instant('dataModels.duplicate-object'));
-                return false;
-             } else {
-                vm.dataModelName.push(angular.lowercase(vm.stepperData.name.trim()));
-             }
 
-            if(vm.dataModelSavedName.length > 0 ) {
-                if(vm.dataModelSavedName.indexOf(angular.lowercase(vm.stepperData.name.trim())) !== -1) {
-                    vm.stepperState = 0;    // keeps track of the current stepper step (0-3)
-                    vm.stepperMode = "";    // either CREATE or EDIT. Usefull for hiding/showing the delete option
-                    toast.showError($translate.instant('dataModels.duplicate-object'));
-                    return false;
-                }
-            }
-        }
 
-        if(node !== null) {
-          if(angular.lowercase(node.label) !== angular.lowercase(vm.stepperData.name.trim())) {
-            if(vm.dataModelSavedName.indexOf(angular.lowercase(vm.stepperData.name.trim())) !== -1) {
-                vm.stepperState = 0;    // keeps track of the current stepper step (0-3)
-                vm.stepperMode = "";    // either CREATE or EDIT. Usefull for hiding/showing the delete option
-                toast.showError($translate.instant('dataModels.duplicate-object'));
-                return false;
-             } else {
-                vm.dataModelName.push(angular.lowercase(vm.stepperData.name.trim()));
-             }
+		} else {
+			// create a new node id for a new object creation stepper
+			vm.stepperData.node_id = vm.nodes.length + 1;
 
-            }
-        }
+		}
+		$mdDialog.show({
+			controller: function () {
+				return vm
+			}, // use the current controller (this) as the mdDialog controller
+			controllerAs: 'vm',
+			templateUrl: objectStepper,
+			parent: angular.element($document[0].body),
+			fullscreen: true,
+			targetEvent: targetEvent
+		});
+	};
 
-        if (node) { // handle an existing node
-            // update the node
-            node.datamodelObject = dmo
-            node.label = vm.stepperData.name;
-            node.group = vm.stepperData.type;
+	// listen for datamodel stepper enter keypresses
+	vm.onStepperEnter = function () {
+		$timeout(function () {
+			// handle object info tab
+			if (vm.stepperState === 0) {
+				angular.element('#stepperNext').click();
+				// handle attributes tab
+			} else if (vm.stepperState === 1) {
+				vm.stepperData.currentAttribute.length === 0 ? angular.element('#stepperNext').click() : angular.element('#stepperAddAttrButton').click();
 
-            // merge the node changes back into nodes
-            vm.nodes.update(node);
+				// handle relationships tab
+			} else if (vm.stepperState === 2) {
+				angular.element('#stepperNext').click();
 
-        } else { // handle a new node
-            // add a new node into the nodes list
-            vm.nodes.add({
-                id: nodeId,
-                label: dmo.name,
-                group: dmo.type,
-                datamodelObject: dmo
-            });
-        }
+				// handle review tab
+			} else if (vm.stepperState === 3) {
+				angular.element('#stepperSubmit').click();
+			}
+		});
+	}
 
-        // update the parent relationship
+	// process new and edited objects from a stepper submit click
+	vm.onStepperSubmit = function () {
+		// create the data model object to be submitted
+		var dmo = createDatamodelObject(
+			vm.stepperData.id,
+			vm.stepperData.name.trim(),
+			vm.stepperData.desc,
+			vm.stepperData.type,
+			vm.stepperData.attributes,
+			vm.stepperData.logoFile
+		);
+
+		// get the nodeId and the node (if it exists)
+		var nodeId = vm.stepperData.node_id;
+		var node = vm.nodes.get(nodeId); // this is null if no node exists with this id
+		if (node == null) {
+			if (vm.dataModelName.indexOf(angular.lowercase(vm.stepperData.name.trim())) !== -1) {
+				vm.stepperState = 0; // keeps track of the current stepper step (0-3)
+				vm.stepperMode = ""; // either CREATE or EDIT. Usefull for hiding/showing the delete option
+				toast.showError($translate.instant('dataModels.duplicate-object'));
+				return false;
+			} else {
+				vm.dataModelName.push(angular.lowercase(vm.stepperData.name.trim()));
+			}
+
+			if (vm.dataModelSavedName.length > 0) {
+				if (vm.dataModelSavedName.indexOf(angular.lowercase(vm.stepperData.name.trim())) !== -1) {
+					vm.stepperState = 0; // keeps track of the current stepper step (0-3)
+					vm.stepperMode = ""; // either CREATE or EDIT. Usefull for hiding/showing the delete option
+					toast.showError($translate.instant('dataModels.duplicate-object'));
+					return false;
+				}
+			}
+		}
+
+		if (node !== null) {
+			if (angular.lowercase(node.label) !== angular.lowercase(vm.stepperData.name.trim())) {
+				if (vm.dataModelSavedName.indexOf(angular.lowercase(vm.stepperData.name.trim())) !== -1) {
+					vm.stepperState = 0; // keeps track of the current stepper step (0-3)
+					vm.stepperMode = ""; // either CREATE or EDIT. Usefull for hiding/showing the delete option
+					toast.showError($translate.instant('dataModels.duplicate-object'));
+					return false;
+				} else {
+					vm.dataModelName.push(angular.lowercase(vm.stepperData.name.trim()));
+				}
+
+			}
+		}
+
+		if (node) { // handle an existing node
+			// update the node
+			node.datamodelObject = dmo
+			node.label = vm.stepperData.name;
+			node.group = vm.stepperData.type;
+
+			// merge the node changes back into nodes
+			vm.nodes.update(node);
+
+		} else { // handle a new node
+			// add a new node into the nodes list
+			vm.nodes.add({
+				id: nodeId,
+				label: dmo.name,
+				group: dmo.type,
+				datamodelObject: dmo
+			});
+		}
+
+		// update the parent relationship
+		//var parent_nodeId = vm.stepperData.parent_node_id;
+		var child_nodeId = vm.stepperData.child_node_id;
+		var arr = angular.copy(child_nodeId);
+
+		var edgesVal = []; // array of {to: child_dmo_id, from: parent_dmo_id} edges
+		//parent_nodeId = parent_nodeId.join();
+		var edge = vm.edges.get().filter(function (edge) { // get the existing edge if it exists, otherwise get empty object
+			return edge.to === nodeId;
+		}).pop() || {};
+
+
+		if (angular.isDefined(child_nodeId)) { // handle a parent that exists
+
+			if (child_nodeId.length > 0) { // update endpoints
+				angular.forEach(arr, function (value, key) {
+
+					edgesVal.push({
+						to: value,
+						from: nodeId
+					});
+
+					// add edge to edges
+				});
+
+				if (edge.id) {
+					// update existing edge
+					vm.edges.update(edgesVal);
+				} else { // create new edge
+					edge.id = vm.edges.length + 1;
+					edgesVal.forEach(edgeV => {
+						vm.edges.add({
+							id: edge.id++,
+							to: edgeV.to,
+							from: edgeV.from
+						});
+					});
+
+
+					//vm.edges.add(edge);
+				}
+
+			}
+		}
+
         var parent_nodeId = vm.stepperData.parent_node_id;
-        var edge = vm.edges.get().filter(function (edge) { // get the existing edge if it exists, otherwise get empty object
-            return edge.to === nodeId;
-        }).pop() || {};
         if (parent_nodeId) { // handle a parent that exists
             // update endpoints
             edge.to = nodeId;
@@ -555,95 +643,101 @@ export function DataModelController($scope, $mdDialog, $document, $stateParams, 
                 edge.id = vm.edges.length + 1;
                 vm.edges.add(edge);
             }
-        } else { // handle a parent that does not exist
-            if (edge.id) { // delete an existing edge
-                vm.edges.remove(edge.id);
-            }
         }
 
-        // plot the data
-        plotDatamodel();
-
-        // hide the stepper and reset its state
-        vm.cancel();
-    };
-
-    // delete the object and reload the datamodel
-    vm.onStepperDelete = function () {
-        // confirm delete
-        var confirm = $mdDialog.confirm()
-            .title('Delete Object')
-            .htmlContent("Are you sure you want to delete this object?")
-            .cancel("Cancel")
-            .ok("Submit");
-        $mdDialog.show(confirm).then(function () {
-
-            // remove the node
-            var nodeId = vm.stepperData.node_id;
-            vm.nodes.remove(nodeId);
-
-            // remove any edge utilizing this node
-            var old_edges = vm.edges.get().filter(edge => {
-                return edge.to === nodeId || edge.from === nodeId;
-            });
-            vm.edges.remove(old_edges);
-
-            // queue the object up for deletion if it has an ID
-            if (vm.stepperData.id) {
-                objectDeleteList.push(vm.stepperData.id);
-                objectDeleteNameList.push(vm.stepperData.name);
-            }
-
-            // close the dialog
-            vm.cancel();
-        });
-    };
-
-    // add a datamodel object attribute to the stepper's current data
-    vm.addDatamodelObjectAttribute = function () {
-        // add the attribute if it exists
-        var inArray = vm.attrName.indexOf(angular.lowercase(vm.stepperData.currentAttribute.trim()));
-        if(inArray !== -1) {
-            vm.stepperState = 1;
-            vm.stepperMode = "";
-            toast.showError($translate.instant('dataModels.duplicateAttribute'));
-            return false;
+        if (angular.isUndefined(child_nodeId) && !parent_nodeId){
+             if (edge.id) { // delete an existing edge
+                 vm.edges.remove(edge.id);
+             }
         }
-        if (vm.stepperData.currentAttribute) {
-           vm.stepperData.attributes.push(vm.stepperData.currentAttribute.trim());
-           vm.attrName.push(angular.lowercase(vm.stepperData.currentAttribute.trim()));
-        }
-        vm.stepperData.currentAttribute = "";
-    };
+		$timeout(function () {
+			plotDatamodel();
+		}, 5000);
 
-    // update the datamodel and exit edit mode
-    vm.acceptDatamodelEdit = function () {
 
-       vm.dataModelName = vm.dataModelName.filter(val => !objectDeleteNameList.includes(val));
-       vm.dataModelSavedName = vm.dataModelSavedName.filter(val => !objectDeleteNameList.includes(val));
+		// plot the data
+		plotDatamodel();
 
-        objectDeleteList.forEach(id_to_delete => {
-            // delete the object by ID
-            datamodelService.deleteDatamodelObject(
-                id_to_delete
-            );
-        });
+		// hide the stepper and reset its state
+		vm.cancel();
+	};
 
-        saveDatamodel();
-        vm.toggleDMEditMode();
-    };
+	// delete the object and reload the datamodel
+	vm.onStepperDelete = function () {
+		// confirm delete
+		var confirm = $mdDialog.confirm()
+			.title('Delete Object')
+			.htmlContent("Are you sure you want to delete this object?")
+			.cancel("Cancel")
+			.ok("Submit");
+		$mdDialog.show(confirm).then(function () {
 
-    vm.rejectDatamodelEdit = function() {
-        loadDatamodel();
-    };
+			// remove the node
+			var nodeId = vm.stepperData.node_id;
+			vm.nodes.remove(nodeId);
 
-    vm.updateAttribute =  function (attributeName, index){
-        $scope.editing = false;
-        vm.stepperData.attributes[index] = attributeName;
-        vm.attrName[index] = angular.lowercase(attributeName.trim());
-    }
-    vm.deleteAttribute =  function (index){
-        vm.stepperData.attributes.splice(index, 1);
-        vm.attrName.splice(index,1);
-    }
+			// remove any edge utilizing this node
+			var old_edges = vm.edges.get().filter(edge => {
+				return edge.to === nodeId || edge.from === nodeId;
+			});
+			vm.edges.remove(old_edges);
+
+			// queue the object up for deletion if it has an ID
+			if (vm.stepperData.id) {
+				objectDeleteList.push(vm.stepperData.id);
+				objectDeleteNameList.push(vm.stepperData.name);
+			}
+
+			// close the dialog
+			vm.cancel();
+		});
+	};
+
+	// add a datamodel object attribute to the stepper's current data
+	vm.addDatamodelObjectAttribute = function () {
+		// add the attribute if it exists
+		var inArray = vm.attrName.indexOf(angular.lowercase(vm.stepperData.currentAttribute.trim()));
+		if (inArray !== -1) {
+			vm.stepperState = 1;
+			vm.stepperMode = "";
+			toast.showError($translate.instant('dataModels.duplicateAttribute'));
+			return false;
+		}
+		if (vm.stepperData.currentAttribute) {
+			vm.stepperData.attributes.push(vm.stepperData.currentAttribute.trim());
+			vm.attrName.push(angular.lowercase(vm.stepperData.currentAttribute.trim()));
+		}
+		vm.stepperData.currentAttribute = "";
+	};
+
+	// update the datamodel and exit edit mode
+	vm.acceptDatamodelEdit = function () {
+
+		vm.dataModelName = vm.dataModelName.filter(val => !objectDeleteNameList.includes(val));
+		vm.dataModelSavedName = vm.dataModelSavedName.filter(val => !objectDeleteNameList.includes(val));
+
+		objectDeleteList.forEach(id_to_delete => {
+			// delete the object by ID
+			datamodelService.deleteDatamodelObject(
+				id_to_delete
+			);
+		});
+
+		saveDatamodel();
+		vm.toggleDMEditMode();
+	};
+
+	vm.rejectDatamodelEdit = function () {
+		loadDatamodel();
+	};
+
+	vm.updateAttribute = function (attributeName, index) {
+		$scope.editing = false;
+		vm.stepperData.attributes[index] = attributeName;
+		vm.attrName[index] = angular.lowercase(attributeName.trim());
+	}
+	vm.deleteAttribute = function (index) {
+		vm.stepperData.attributes.splice(index, 1);
+		vm.attrName.splice(index, 1);
+	}
 }

--- a/ui/src/app/data_models/datamodel-object-stepper.tpl.html
+++ b/ui/src/app/data_models/datamodel-object-stepper.tpl.html
@@ -88,7 +88,7 @@
               <div>
               </div>
             </md-input-container>
-              <div ng-hide ="vm.stepperData.type == 'Device'">Note:- If No Icon Uploaded Then Default Icon Of Assets Will Be Applied.</div>
+            <div ng-hide ="vm.stepperData.type == 'Device'">Note:- If No Icon Uploaded Then Default Icon Of Assets Will Be Applied.</div>
           </md-content>
         </md-tab>
 
@@ -111,7 +111,7 @@
             </md-list-item>
 
 
-            
+
             <md-input-container class="md-block" ng-keypress="$event.keyCode === 13 && vm.onStepperEnter();">
               <label>Attribute Name</label>
               <input md-maxlength="256" md-no-asterisk="" name="attribute" ng-model="vm.stepperData.currentAttribute" ng-keypress="$event.keyCode === 13 && alert('c')">
@@ -130,12 +130,23 @@
           <md-content class="md-padding">
             <md-input-container class="md-block" ng-keypress="$event.keyCode === 13 && vm.onStepperEnter();">
               <label>Parent</label>
-              <md-select name="tempusType" ng-model="vm.stepperData.parent_node_id" ng-init="nodes = vm.getNodes()">
+              <md-select  name="tempusType" ng-model="vm.stepperData.parent_node_id" ng-init="nodes = vm.getNodes()">
                 <md-option ng-value="null">None</md-option>
-                <md-option ng-repeat="node in nodes" ng-value="node.id">{{node.label}}</md-option>
+                <md-option  ng-repeat="node in nodes" ng-if="vm.stepperData.child_node_id.indexOf(node.id) == -1 || vm.stepperData.child_node_id == undefined" ng-value="node.id">{{node.label}}</md-option>
+              </md-select>
+            </md-input-container>
+
+          </md-content>
+
+          <md-content class="md-padding">
+            <md-input-container class="md-block" ng-keypress="$event.keyCode === 13 && vm.onStepperEnter();">
+              <label>Child</label>
+              <md-select multiple="{{false}}" name="tempusType" ng-model="vm.stepperData.child_node_id" ng-init="nodes = vm.getNodes()">
+                <md-option ng-repeat="node in nodes" ng-if ="vm.stepperData.parent_node_id !== node.id" ng-value="node.id">{{node.label}}</md-option>
               </md-select>
             </md-input-container>
           </md-content>
+
         </md-tab>
 
         <md-tab label="Review" ng-click="vm.stepperState = 3" ng-disabled="!vm.stepperData.name || !vm.stepperData.type">
@@ -161,11 +172,11 @@
               <label>Parent: {{vm.stepperData.parent_node_id ? vm.nodes.get(vm.stepperData.parent_node_id).label : "--"}}</label>
             </md-list-item>
 
-              <md-subheader class="md-no-sticky reviewHeader">Image</md-subheader>
+            <md-subheader class="md-no-sticky reviewHeader">Image</md-subheader>
 
-              <md-list-item>
-                  <label>Icon:<img class="" style="width: 98%; margin-top: -1%;"ng-src="{{vm.stepperData.logoFile}}"></label>
-              </md-list-item>
+            <md-list-item>
+              <label>Icon:<img class="" style="width: 98%; margin-top: -1%;"ng-src="{{vm.stepperData.logoFile}}"></label>
+            </md-list-item>
 
           </md-content>
         </md-tab>
@@ -181,10 +192,10 @@
         Back
       </md-button>
       <md-button ng-click="vm.stepperState = vm.stepperState + 1" style="margin-right:20px;" ng-if="3 > vm.stepperState" ng-disabled="!vm.stepperData.name || !vm.stepperData.type" id="stepperNext">
-         Next
+        Next
       </md-button>
       <md-button ng-disabled="$root.loading || !theForm.$valid" type="submit" style="margin-right:20px;" ng-if="3 === vm.stepperState" id="stepperSubmit">
-         Submit
+        Submit
       </md-button>
     </md-dialog-actions>
   </form>

--- a/ui/src/app/data_models/datamodel-object-stepper.tpl.html
+++ b/ui/src/app/data_models/datamodel-object-stepper.tpl.html
@@ -132,7 +132,7 @@
               <label>Parent</label>
               <md-select  name="tempusType" ng-model="vm.stepperData.parent_node_id" ng-init="nodes = vm.getNodes()">
                 <md-option ng-value="null">None</md-option>
-                <md-option  ng-repeat="node in nodes" ng-if="vm.stepperData.child_node_id.indexOf(node.id) == -1 || vm.stepperData.child_node_id == undefined" ng-value="node.id">{{node.label}}</md-option>
+                <md-option  ng-repeat="node in nodes" ng-if="vm.stepperData.child_node_id == undefined || vm.stepperData.child_node_id.indexOf(node.id) == -1 " ng-value="node.id">{{node.label}}</md-option>
               </md-select>
             </md-input-container>
 
@@ -171,7 +171,9 @@
             <md-list-item>
               <label>Parent: {{vm.stepperData.parent_node_id ? vm.nodes.get(vm.stepperData.parent_node_id).label : "--"}}</label>
             </md-list-item>
-
+            <md-list-item>
+              <p class="dmoFont"><span translate>dataModels.child</span>: <span class="datamodel-value">{{vm.childNode.length > 0 ? vm.childName : "None"}}</span></p>
+            </md-list-item>
             <md-subheader class="md-no-sticky reviewHeader">Image</md-subheader>
 
             <md-list-item>

--- a/ui/src/app/data_models/object_info.tpl.html
+++ b/ui/src/app/data_models/object_info.tpl.html
@@ -65,6 +65,10 @@
                 <md-list-item>
                     <p class="dmoFont"><span translate>dataModels.parent</span>: <span class="datamodel-value">{{vm.nodeValue.datamodelObject.parent_id ? vm.nodeValue.datamodelObject.parent : "None"}}</span></p>
                 </md-list-item>
+                <md-list-item>
+                    <p class="dmoFont"><span translate>dataModels.child</span>: <span class="datamodel-value">{{vm.childNode.length > 0 ? vm.childName : "None"}}</span></p>
+                </md-list-item>
+
             </div>
         </div>
 

--- a/ui/src/app/locale/locale.constant.js
+++ b/ui/src/app/locale/locale.constant.js
@@ -624,6 +624,7 @@ export default angular.module('tempus.locale', [])
                     "relationships":"Relationships",
                     "image":"Icon",
                     "parent":"Parent",
+                    "child": "Child(s)",
                     "noAttribute":"No Attributes",
                     "duplicateAttribute":"Attribute already created, please use different name.",
                     "delete":"Delete Data Model(s)",


### PR DESCRIPTION
This PR contains the UI changes in datamodel, Now user can also select multiple objects and make them as a children for a single parent object.

Thank you for submitting a contribution to Tempus.

In order to streamline the review of the contribution please
ensure the following steps have been taken:
### For all changes:
- [x] Is there a Waffle ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with Tempus-XXXX where XXXX is the waffle number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically dev)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn clean install at the root Tempus folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] Have you added documentation for any UI or API related changes to the /docs folder

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
