### PR TITLE
Tempus 998 english metric canadian unit system

### DIFF
--- a/application/src/it/java/com/hashmapinc/server/HybridIntegrationTestSuite.java
+++ b/application/src/it/java/com/hashmapinc/server/HybridIntegrationTestSuite.java
@@ -57,17 +57,16 @@ public class HybridIntegrationTestSuite {
     }
 
     private static List<CustomCassandraCQLUnit.NamedDataset> getUpgradeDataSets(){
-        /*List<CustomCassandraCQLUnit.NamedDataset> dataSets = new ArrayList<>();
+        List<CustomCassandraCQLUnit.NamedDataset> dataSets = new ArrayList<>();
         dataSets.add(new CustomCassandraCQLUnit.NamedDataset("1.cql", new ClassPathCQLDataSet("cassandra/upgrade/1.cql" , false, false)));
-        return dataSets;*/
-        return Collections.emptyList();
+        return dataSets;
     }
 
     private static CustomSqlUnit sqlUnit = new CustomSqlUnit(
             Arrays.asList("sql/hsql/schema.sql", "sql/system-data.sql"),
             "sql/drop-all-tables.sql",
             "sql-test.properties",
-            Collections.emptyList());
+            Arrays.asList("sql/hsql/upgrade/1.sql"));
 
 
     @ClassRule

--- a/application/src/it/java/com/hashmapinc/server/SqlIntegrationTestSuite.java
+++ b/application/src/it/java/com/hashmapinc/server/SqlIntegrationTestSuite.java
@@ -45,7 +45,8 @@ public class SqlIntegrationTestSuite {
             Arrays.asList("sql/hsql/schema.sql", "sql/system-data.sql"),
             "sql/drop-all-tables.sql",
             "sql-test.properties",
-            Collections.emptyList());
+            Arrays.asList("sql/hsql/upgrade/1.sql"));
+
     @ClassRule
     public static TestRule ruleChain = RuleChain.outerRule(wiremock)
             .around(sqlUnit);

--- a/application/src/it/java/com/hashmapinc/server/controller/BaseTenantControllerTest.java
+++ b/application/src/it/java/com/hashmapinc/server/controller/BaseTenantControllerTest.java
@@ -221,34 +221,34 @@ public abstract class BaseTenantControllerTest extends AbstractControllerTest {
     @Test
     public void testSaveAndGetUnitSystem() throws Exception {
         loginTenantAdmin();
-        doPost("/api/unit-system/tenant/"+ tenantAdmin.getTenantId(), "UK",String.class);
+        doPost("/api/unit-system/tenant/"+ tenantAdmin.getTenantId(), "English",String.class);
         String unitSystem = doGet("/api/unit-system/tenant/"+ tenantAdmin.getTenantId(), String.class);
-        Assert.assertEquals("{\"unit_system\":\"UK\"}", unitSystem);
+        Assert.assertEquals("{\"unit_system\":\"English\"}", unitSystem);
     }
 
     @Test
     public void testUpdateUnitSystem() throws Exception {
         loginTenantAdmin();
-        doPost("/api/unit-system/tenant/"+ tenantAdmin.getTenantId(), "UK",String.class);
-        doPost("/api/unit-system/tenant/"+ tenantAdmin.getTenantId(), "SI",String.class);
+        doPost("/api/unit-system/tenant/"+ tenantAdmin.getTenantId(), "English",String.class);
+        doPost("/api/unit-system/tenant/"+ tenantAdmin.getTenantId(), "Metric",String.class);
         String unitSystem = doGet("/api/unit-system/tenant/"+ tenantAdmin.getTenantId(), String.class);
-        Assert.assertEquals("{\"unit_system\":\"SI\"}", unitSystem);
+        Assert.assertEquals("{\"unit_system\":\"Metric\"}", unitSystem);
     }
 
     @Test
     public void testGetDefaultUnitSystem() throws Exception {
         loginTenantAdmin();
         String unitSystem = doGet("/api/unit-system/tenant/"+ tenantAdmin.getTenantId(), String.class);
-        Assert.assertEquals("{\"unit_system\":\"SI\"}", unitSystem);
+        Assert.assertEquals("{\"unit_system\":\"Metric\"}", unitSystem);
     }
 
     @Test
     public void testGetUnitSystemForCustomerUser() throws Exception {
         loginTenantAdmin();
-        doPost("/api/unit-system/tenant/"+ tenantAdmin.getTenantId(), "UK",String.class);
+        doPost("/api/unit-system/tenant/"+ tenantAdmin.getTenantId(), "Canadian",String.class);
         logout();
         loginCustomerUser();
         String unitSystem = doGet("/api/unit-system/tenant/"+ customerUser.getTenantId(), String.class);
-        Assert.assertEquals("{\"unit_system\":\"UK\"}", unitSystem);
+        Assert.assertEquals("{\"unit_system\":\"Canadian\"}", unitSystem);
     }
 }

--- a/application/src/main/java/com/hashmapinc/server/actors/plugin/PluginProcessingContext.java
+++ b/application/src/main/java/com/hashmapinc/server/actors/plugin/PluginProcessingContext.java
@@ -130,7 +130,7 @@ public final class PluginProcessingContext implements PluginContext {
             List<AttributeKvEntry> collect;
             if (entry.isPresent()) {
                 collect = Collections.singletonList(entry.get());
-                List<AttributeKvEntry> attributeKvEntries = convertAttributeKvEntriesToUnitSystem(collect);
+                List<AttributeKvEntry> attributeKvEntries = convertKvEntriesToUnitSystem(collect, BaseAttributeKvEntry.class);
                 if (attributeKvEntries != null && !attributeKvEntries.isEmpty())
                     return Optional.ofNullable(attributeKvEntries.get(0));
             }
@@ -142,7 +142,7 @@ public final class PluginProcessingContext implements PluginContext {
     public void loadAttributes(EntityId entityId, String attributeType, Collection<String> attributeKeys, final PluginCallback<List<AttributeKvEntry>> callback) {
         validate(entityId, new ValidationCallback(callback, ctx -> {
             ListenableFuture<List<AttributeKvEntry>> future = pluginCtx.attributesService.find(entityId, attributeType, attributeKeys);
-            ListenableFuture<List<AttributeKvEntry>> transformedKvEntries = Futures.transform(future , this::convertAttributeKvEntriesToUnitSystem);
+            ListenableFuture<List<AttributeKvEntry>> transformedKvEntries = Futures.transform(future , (Function<List<AttributeKvEntry>, List<AttributeKvEntry>>)entries -> convertKvEntriesToUnitSystem(entries, BaseAttributeKvEntry.class));
             Futures.addCallback(transformedKvEntries, getCallback(callback, v -> v), executor);
         }));
     }
@@ -151,7 +151,7 @@ public final class PluginProcessingContext implements PluginContext {
     public void loadAttributes(EntityId entityId, String attributeType, PluginCallback<List<AttributeKvEntry>> callback) {
         validate(entityId, new ValidationCallback(callback, ctx -> {
             ListenableFuture<List<AttributeKvEntry>> future = pluginCtx.attributesService.findAll(entityId, attributeType);
-            ListenableFuture<List<AttributeKvEntry>> transformedKvEntries = Futures.transform(future , this::convertAttributeKvEntriesToUnitSystem);
+            ListenableFuture<List<AttributeKvEntry>> transformedKvEntries = Futures.transform(future , (Function<List<AttributeKvEntry>, List<AttributeKvEntry>>) entries -> convertKvEntriesToUnitSystem(entries, BaseAttributeKvEntry.class));
             Futures.addCallback(transformedKvEntries, getCallback(callback, v -> v), executor);
         }));
     }
@@ -162,7 +162,7 @@ public final class PluginProcessingContext implements PluginContext {
             List<ListenableFuture<List<AttributeKvEntry>>> futures = new ArrayList<>();
             attributeTypes.forEach(attributeType -> {
                 ListenableFuture<List<AttributeKvEntry>> future = pluginCtx.attributesService.findAll(entityId , attributeType);
-                ListenableFuture<List<AttributeKvEntry>> transformedKvEntries = Futures.transform(future , this::convertAttributeKvEntriesToUnitSystem);
+                ListenableFuture<List<AttributeKvEntry>> transformedKvEntries = Futures.transform(future , (Function<List<AttributeKvEntry>, List<AttributeKvEntry>>) entries -> convertKvEntriesToUnitSystem(entries, BaseAttributeKvEntry.class));
                 futures.add(transformedKvEntries);
             });
             convertFuturesAndAddCallback(callback, futures);
@@ -175,7 +175,7 @@ public final class PluginProcessingContext implements PluginContext {
             List<ListenableFuture<List<AttributeKvEntry>>> futures = new ArrayList<>();
             attributeTypes.forEach(attributeType -> {
                 ListenableFuture<List<AttributeKvEntry>> future = pluginCtx.attributesService.find(entityId , attributeType , attributeKeys);
-                ListenableFuture<List<AttributeKvEntry>> transformedKvEntries = Futures.transform(future , this::convertAttributeKvEntriesToUnitSystem);
+                ListenableFuture<List<AttributeKvEntry>> transformedKvEntries = Futures.transform(future , (Function<List<AttributeKvEntry>, List<AttributeKvEntry>>) entries -> convertKvEntriesToUnitSystem(entries, BaseAttributeKvEntry.class));
                 futures.add(transformedKvEntries);
             });
             convertFuturesAndAddCallback(callback, futures);
@@ -220,7 +220,7 @@ public final class PluginProcessingContext implements PluginContext {
     public void loadTimeseries(final EntityId entityId, final List<TsKvQuery> queries, final PluginCallback<List<TsKvEntry>> callback) {
         validate(entityId, new ValidationCallback(callback, ctx -> {
             ListenableFuture<List<TsKvEntry>> future = pluginCtx.tsService.findAll(entityId, queries);
-            ListenableFuture<List<TsKvEntry>> transformedKvEntries = Futures.transform(future , this::convertTsKvEntriesToUnitSystem);
+            ListenableFuture<List<TsKvEntry>> transformedKvEntries = Futures.transform(future , (Function<List<TsKvEntry>, List<TsKvEntry>>) entries -> convertKvEntriesToUnitSystem(entries, BasicTsKvEntry.class));
             Futures.addCallback(transformedKvEntries, getCallback(callback, v -> v), executor);
         }));
     }
@@ -229,7 +229,7 @@ public final class PluginProcessingContext implements PluginContext {
     public void loadDepthSeries(final EntityId entityId, final List<DsKvQuery> queries, final PluginCallback<List<DsKvEntry>> callback) {
         validate(entityId, new ValidationCallback(callback, ctx -> {
             ListenableFuture<List<DsKvEntry>> future = pluginCtx.dsService.findAll(entityId, queries);
-            ListenableFuture<List<DsKvEntry>> transformedKvEntries = Futures.transform(future , this::convertDsKvEntriesToUnitSystem);
+            ListenableFuture<List<DsKvEntry>> transformedKvEntries = Futures.transform(future , (Function<List<DsKvEntry>, List<DsKvEntry>>) entries -> convertKvEntriesToUnitSystem(entries, BasicDsKvEntry.class));
             Futures.addCallback(transformedKvEntries, getCallback(callback, v -> v), executor);
         }));
     }
@@ -238,7 +238,7 @@ public final class PluginProcessingContext implements PluginContext {
     public void loadLatestTimeseries(final EntityId entityId, final PluginCallback<List<TsKvEntry>> callback) {
         validate(entityId, new ValidationCallback(callback, ctx -> {
             ListenableFuture<List<TsKvEntry>> future = pluginCtx.tsService.findAllLatest(entityId);
-            ListenableFuture<List<TsKvEntry>> transformedKvEntries = Futures.transform(future , this::convertTsKvEntriesToUnitSystem);
+            ListenableFuture<List<TsKvEntry>> transformedKvEntries = Futures.transform(future , (Function<List<TsKvEntry>, List<TsKvEntry>>) entries -> convertKvEntriesToUnitSystem(entries, BasicTsKvEntry.class));
             Futures.addCallback(transformedKvEntries, getCallback(callback, v -> v), executor);
         }));
     }
@@ -293,7 +293,7 @@ public final class PluginProcessingContext implements PluginContext {
     public void loadLatestTimeseries(final EntityId entityId, final Collection<String> keys, final PluginCallback<List<TsKvEntry>> callback) {
         validate(entityId, new ValidationCallback(callback, ctx -> {
             ListenableFuture<List<TsKvEntry>> rsListFuture = pluginCtx.tsService.findLatest(entityId, keys);
-            ListenableFuture<List<TsKvEntry>> transformedKvEntries = Futures.transform(rsListFuture , this::convertTsKvEntriesToUnitSystem);
+            ListenableFuture<List<TsKvEntry>> transformedKvEntries = Futures.transform(rsListFuture , (Function<List<TsKvEntry>, List<TsKvEntry>>) entries -> convertKvEntriesToUnitSystem(entries, BasicTsKvEntry.class));
             Futures.addCallback(transformedKvEntries, getCallback(callback, v -> v), executor);
         }));
     }
@@ -306,7 +306,7 @@ public final class PluginProcessingContext implements PluginContext {
         }
         validate(entityId, new ValidationCallback(callback, ctx -> {
             ListenableFuture<List<TsKvEntry>> rsListFuture = pluginCtx.tsService.findLatest(entityId, keys);
-            ListenableFuture<List<TsKvEntry>> transformedKvEntries = Futures.transform(rsListFuture , this::convertTsKvEntriesToUnitSystem);
+            ListenableFuture<List<TsKvEntry>> transformedKvEntries = Futures.transform(rsListFuture , (Function<List<TsKvEntry>, List<TsKvEntry>>) entries -> convertKvEntriesToUnitSystem(entries, BasicTsKvEntry.class));
             Futures.addCallback(transformedKvEntries, getCallback(callback, v -> v), executor);
         }));
     }
@@ -315,7 +315,7 @@ public final class PluginProcessingContext implements PluginContext {
     public void loadLatestDepthSeries(final EntityId entityId, final PluginCallback<List<DsKvEntry>> callback) {
         validate(entityId, new ValidationCallback(callback, ctx -> {
             ListenableFuture<List<DsKvEntry>> future = pluginCtx.dsService.findAllLatest(entityId);
-            ListenableFuture<List<DsKvEntry>> transformedKvEntries = Futures.transform(future , this::convertDsKvEntriesToUnitSystem);
+            ListenableFuture<List<DsKvEntry>> transformedKvEntries = Futures.transform(future , (Function<List<DsKvEntry>, List<DsKvEntry>>) entries -> convertKvEntriesToUnitSystem(entries, BasicDsKvEntry.class));
             Futures.addCallback(transformedKvEntries, getCallback(callback, v -> v), executor);
         }));
     }
@@ -324,7 +324,7 @@ public final class PluginProcessingContext implements PluginContext {
     public void loadLatestDepthSeries(final EntityId entityId, final Collection<String> keys, final PluginCallback<List<DsKvEntry>> callback) {
         validate(entityId, new ValidationCallback(callback, ctx -> {
             ListenableFuture<List<DsKvEntry>> rsListFuture = pluginCtx.dsService.findLatest(entityId, keys);
-            ListenableFuture<List<DsKvEntry>> transformedKvEntries = Futures.transform(rsListFuture , this::convertDsKvEntriesToUnitSystem);
+            ListenableFuture<List<DsKvEntry>> transformedKvEntries = Futures.transform(rsListFuture , (Function<List<DsKvEntry>, List<DsKvEntry>>) entries -> convertKvEntriesToUnitSystem(entries, BasicDsKvEntry.class));
             Futures.addCallback(transformedKvEntries, getCallback(callback, v -> v), executor);
         }));
     }
@@ -337,7 +337,7 @@ public final class PluginProcessingContext implements PluginContext {
         }
         validate(entityId, new ValidationCallback(callback, ctx -> {
             ListenableFuture<List<DsKvEntry>> rsListFuture = pluginCtx.dsService.findLatest(entityId, keys);
-            ListenableFuture<List<DsKvEntry>> transformedKvEntries = Futures.transform(rsListFuture , this::convertDsKvEntriesToUnitSystem);
+            ListenableFuture<List<DsKvEntry>> transformedKvEntries = Futures.transform(rsListFuture , (Function<List<DsKvEntry>, List<DsKvEntry>>) entries -> convertKvEntriesToUnitSystem(entries, BasicDsKvEntry.class));
             Futures.addCallback(transformedKvEntries, getCallback(callback, v -> v), executor);
         }));
     }
@@ -642,76 +642,34 @@ public final class PluginProcessingContext implements PluginContext {
         Futures.addCallback(future, getCallback(callback, v -> v), executor);
     }
 
-    private List<AttributeKvEntry> convertAttributeKvEntriesToUnitSystem(List<AttributeKvEntry> attributeKvEntries) {
+    private <E extends KvEntry, T extends E> List<E> convertKvEntriesToUnitSystem(List<E> kvEntries, Class<T> tClass) {
         if (securityCtx.isPresent()) {
-            return convertAttributeKvEntriesToUnitSystemByTenantId(attributeKvEntries , securityCtx.get().getTenantId());
+            return convertKvEntriesToUnitSystemByTenantId(kvEntries , securityCtx.get().getTenantId(), tClass);
         } else {
-            return convertAttributeKvEntriesToUnitSystemByTenantId(attributeKvEntries, nullTenantId);
+            return convertKvEntriesToUnitSystemByTenantId(kvEntries , nullTenantId, tClass);
         }
     }
 
     @Override
-    public List<AttributeKvEntry> convertAttributeKvEntriesToUnitSystemByTenantId(List<AttributeKvEntry> attributeKvEntries, TenantId tenantId) {
-        List<AttributeKvEntry> unitSystemAttributeKvEntries = new ArrayList<>();
+    public <E extends KvEntry, T extends E> List<E> convertKvEntriesToUnitSystemByTenantId(List<E> kvEntries , TenantId tenantId , Class<T> tClass) {
+        List<E> unitSystemKvEntries = new ArrayList<>();
         String unitSystem = getUnitSystem(tenantId);
-        for (AttributeKvEntry attributeKvEntry:  attributeKvEntries) {
-            if (checkDataTypeAndIsUnitPresent(attributeKvEntry)) {
-                Double value = getDoubleValue(attributeKvEntry);
-                DoubleDataEntry dataEntry = convert(unitSystem, attributeKvEntry.getKey(), value, attributeKvEntry.getUnit().orElse(null), attributeKvEntry.getSourceUnit().orElse(null));
-                unitSystemAttributeKvEntries.add(new BaseAttributeKvEntry(dataEntry, attributeKvEntry.getLastUpdateTs()));
+        for (E kvEntry:  kvEntries) {
+            if (checkDataTypeAndIsUnitPresent(kvEntry)) {
+                Double value = getDoubleValue(kvEntry);
+                DoubleDataEntry dataEntry = convert(unitSystem, kvEntry.getKey(), value, kvEntry.getUnit().orElse(null), kvEntry.getSourceUnit().orElse(null));
+                if (tClass.isAssignableFrom(BasicDsKvEntry.class)) {
+                    unitSystemKvEntries.add((E)new BasicDsKvEntry(((DsKvEntry)kvEntry).getDs(), dataEntry));
+                } else if (tClass.isAssignableFrom(BasicTsKvEntry.class)) {
+                    unitSystemKvEntries.add((E)new BasicTsKvEntry(((TsKvEntry) kvEntry).getTs() , dataEntry));
+                } else if (tClass.isAssignableFrom(BaseAttributeKvEntry.class)) {
+                    unitSystemKvEntries.add((E)new BaseAttributeKvEntry(dataEntry, ((AttributeKvEntry)kvEntry).getLastUpdateTs()));
+                }
             } else {
-                unitSystemAttributeKvEntries.add(attributeKvEntry);
+                unitSystemKvEntries.add(kvEntry);
             }
         }
-        return unitSystemAttributeKvEntries;
-    }
-
-    private List<TsKvEntry> convertTsKvEntriesToUnitSystem(List<TsKvEntry> tsKvEntries) {
-        if (securityCtx.isPresent()) {
-            return convertTsKvEntriesToUnitSystemByTenantId(tsKvEntries , securityCtx.get().getTenantId());
-        } else {
-            return convertTsKvEntriesToUnitSystemByTenantId(tsKvEntries , nullTenantId);
-        }
-    }
-
-    @Override
-    public List<TsKvEntry> convertTsKvEntriesToUnitSystemByTenantId(List<TsKvEntry> tsKvEntries, TenantId tenantId) {
-        List<TsKvEntry> unitSystemTsKvEntries = new ArrayList<>();
-        String unitSystem = getUnitSystem(tenantId);
-        for (TsKvEntry tsKvEntry:  tsKvEntries) {
-            if (checkDataTypeAndIsUnitPresent(tsKvEntry)) {
-                Double value = getDoubleValue(tsKvEntry);
-                DoubleDataEntry dataEntry = convert(unitSystem, tsKvEntry.getKey(), value, tsKvEntry.getUnit().orElse(null), tsKvEntry.getSourceUnit().orElse(null));
-                unitSystemTsKvEntries.add(new BasicTsKvEntry(tsKvEntry.getTs(), dataEntry));
-            } else {
-                unitSystemTsKvEntries.add(tsKvEntry);
-            }
-        }
-        return unitSystemTsKvEntries;
-    }
-
-    private List<DsKvEntry> convertDsKvEntriesToUnitSystem(List<DsKvEntry> dsKvEntries) {
-        if (securityCtx.isPresent()) {
-            return convertDsKvEntriesToUnitSystemByTenantId(dsKvEntries , securityCtx.get().getTenantId());
-        } else {
-            return convertDsKvEntriesToUnitSystemByTenantId(dsKvEntries , nullTenantId);
-        }
-    }
-
-    @Override
-    public List<DsKvEntry> convertDsKvEntriesToUnitSystemByTenantId(List<DsKvEntry> dsKvEntries, TenantId tenantId) {
-        List<DsKvEntry> unitSystemDsKvEntries = new ArrayList<>();
-        String unitSystem = getUnitSystem(tenantId);
-        for (DsKvEntry dsKvEntry:  dsKvEntries) {
-            if (checkDataTypeAndIsUnitPresent(dsKvEntry)) {
-                Double value = getDoubleValue(dsKvEntry);
-                DoubleDataEntry dataEntry = convert(unitSystem, dsKvEntry.getKey(), value, dsKvEntry.getUnit().orElse(null), dsKvEntry.getSourceUnit().orElse(null));
-                unitSystemDsKvEntries.add(new BasicDsKvEntry(dsKvEntry.getDs(), dataEntry));
-            } else {
-                unitSystemDsKvEntries.add(dsKvEntry);
-            }
-        }
-        return unitSystemDsKvEntries;
+        return unitSystemKvEntries;
     }
 
     private Double getDoubleValue(KvEntry kvEntry) {

--- a/common/data/src/main/java/com/hashmapinc/server/common/data/kv/BaseAttributeKvEntry.java
+++ b/common/data/src/main/java/com/hashmapinc/server/common/data/kv/BaseAttributeKvEntry.java
@@ -87,6 +87,11 @@ public class BaseAttributeKvEntry implements AttributeKvEntry {
     }
 
     @Override
+    public Optional<String> getSourceUnit() {
+        return kv.getSourceUnit();
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;

--- a/common/data/src/main/java/com/hashmapinc/server/common/data/kv/BasicDsKvEntry.java
+++ b/common/data/src/main/java/com/hashmapinc/server/common/data/kv/BasicDsKvEntry.java
@@ -78,6 +78,11 @@ public class BasicDsKvEntry implements DsKvEntry{
     }
 
     @Override
+    public Optional<String> getSourceUnit() {
+        return kv.getSourceUnit();
+    }
+
+    @Override
     public Double getDs() {
         return ds;
     }

--- a/common/data/src/main/java/com/hashmapinc/server/common/data/kv/BasicKvEntry.java
+++ b/common/data/src/main/java/com/hashmapinc/server/common/data/kv/BasicKvEntry.java
@@ -27,17 +27,24 @@ public abstract class BasicKvEntry implements KvEntry {
 
     private String unit;
 
+    private String sourceUnit;
+
     protected BasicKvEntry(String key) {
         this.key = key;
     }
 
-    protected BasicKvEntry(String key, String unit) {
+    protected BasicKvEntry(String key, String unit, String sourceUnit) {
         this.key = key;
         this.unit = unit;
+        this.sourceUnit = sourceUnit;
     }
 
     public Optional<String> getUnit() {
         return Optional.ofNullable(unit);
+    }
+
+    public Optional<String> getSourceUnit() {
+        return Optional.ofNullable(sourceUnit);
     }
 
     @Override

--- a/common/data/src/main/java/com/hashmapinc/server/common/data/kv/BasicKvEntry.java
+++ b/common/data/src/main/java/com/hashmapinc/server/common/data/kv/BasicKvEntry.java
@@ -39,6 +39,10 @@ public abstract class BasicKvEntry implements KvEntry {
         this.sourceUnit = sourceUnit;
     }
 
+    protected BasicKvEntry(String key, String sourceUnit) {
+        this(key, sourceUnit, sourceUnit);
+    }
+
     public Optional<String> getUnit() {
         return Optional.ofNullable(unit);
     }

--- a/common/data/src/main/java/com/hashmapinc/server/common/data/kv/BasicTsKvEntry.java
+++ b/common/data/src/main/java/com/hashmapinc/server/common/data/kv/BasicTsKvEntry.java
@@ -76,6 +76,11 @@ public class BasicTsKvEntry implements TsKvEntry {
     }
 
     @Override
+    public Optional<String> getSourceUnit() {
+        return kv.getSourceUnit();
+    }
+
+    @Override
     public long getTs() {
         return ts;
     }

--- a/common/data/src/main/java/com/hashmapinc/server/common/data/kv/BooleanDataEntry.java
+++ b/common/data/src/main/java/com/hashmapinc/server/common/data/kv/BooleanDataEntry.java
@@ -27,8 +27,8 @@ public class BooleanDataEntry extends BasicKvEntry {
         this.value = value;
     }
 
-    public BooleanDataEntry(String key, String unit, Boolean value) {
-        super(key, unit);
+    public BooleanDataEntry(String key, String unit, String sourceUnit, Boolean value) {
+        super(key, unit, sourceUnit);
         this.value = value;
     }
 
@@ -66,6 +66,7 @@ public class BooleanDataEntry extends BasicKvEntry {
         return "BooleanDataEntry{" +
                 "value=" + value +
                 ", unit=" + super.getUnit().orElse(null) +
+                ", sourceUnit=" + super.getSourceUnit().orElse(null) +
                 "} " + super.toString();
     }
 

--- a/common/data/src/main/java/com/hashmapinc/server/common/data/kv/BooleanDataEntry.java
+++ b/common/data/src/main/java/com/hashmapinc/server/common/data/kv/BooleanDataEntry.java
@@ -32,6 +32,11 @@ public class BooleanDataEntry extends BasicKvEntry {
         this.value = value;
     }
 
+    public BooleanDataEntry(String key, String sourceUnit, Boolean value) {
+        super(key, sourceUnit);
+        this.value = value;
+    }
+
     @Override
     public DataType getDataType() {
         return DataType.BOOLEAN;

--- a/common/data/src/main/java/com/hashmapinc/server/common/data/kv/DoubleDataEntry.java
+++ b/common/data/src/main/java/com/hashmapinc/server/common/data/kv/DoubleDataEntry.java
@@ -33,6 +33,11 @@ public class DoubleDataEntry extends BasicKvEntry {
         this.value = value;
     }
 
+    public DoubleDataEntry(String key, String sourceUnit, Double value) {
+        super(key, sourceUnit);
+        this.value = value;
+    }
+
     @Override
     public DataType getDataType() {
         return DataType.DOUBLE;

--- a/common/data/src/main/java/com/hashmapinc/server/common/data/kv/DoubleDataEntry.java
+++ b/common/data/src/main/java/com/hashmapinc/server/common/data/kv/DoubleDataEntry.java
@@ -28,8 +28,8 @@ public class DoubleDataEntry extends BasicKvEntry {
         this.value = value;
     }
 
-    public DoubleDataEntry(String key, String unit, Double value) {
-        super(key, unit);
+    public DoubleDataEntry(String key, String unit, String sourceUnit, Double value) {
+        super(key, unit, sourceUnit);
         this.value = value;
     }
 
@@ -67,6 +67,7 @@ public class DoubleDataEntry extends BasicKvEntry {
         return "DoubleDataEntry{" +
                 "value=" + value +
                 ", unit=" + super.getUnit().orElse(null) +
+                ", sourceUnit=" + super.getSourceUnit().orElse(null) +
                 "} " + super.toString();
     }
     

--- a/common/data/src/main/java/com/hashmapinc/server/common/data/kv/KvEntry.java
+++ b/common/data/src/main/java/com/hashmapinc/server/common/data/kv/KvEntry.java
@@ -47,4 +47,6 @@ public interface KvEntry extends Serializable {
     Object getValue();
 
     Optional<String> getUnit();
+
+    Optional<String> getSourceUnit();
 }

--- a/common/data/src/main/java/com/hashmapinc/server/common/data/kv/LongDataEntry.java
+++ b/common/data/src/main/java/com/hashmapinc/server/common/data/kv/LongDataEntry.java
@@ -33,6 +33,11 @@ public class LongDataEntry extends BasicKvEntry {
         this.value = value;
     }
 
+    public LongDataEntry(String key, String sourceUnit, Long value) {
+        super(key, sourceUnit);
+        this.value = value;
+    }
+
     @Override
     public DataType getDataType() {
         return DataType.LONG;

--- a/common/data/src/main/java/com/hashmapinc/server/common/data/kv/LongDataEntry.java
+++ b/common/data/src/main/java/com/hashmapinc/server/common/data/kv/LongDataEntry.java
@@ -28,8 +28,8 @@ public class LongDataEntry extends BasicKvEntry {
         this.value = value;
     }
 
-    public LongDataEntry(String key, String unit, Long value) {
-        super(key, unit);
+    public LongDataEntry(String key, String unit, String sourceUnit, Long value) {
+        super(key, unit, sourceUnit);
         this.value = value;
     }
 
@@ -67,6 +67,7 @@ public class LongDataEntry extends BasicKvEntry {
         return "LongDataEntry{" +
                 "value=" + value +
                 ", unit=" + super.getUnit().orElse(null) +
+                ", sourceUnit=" + super.getSourceUnit().orElse(null) +
                 "} " + super.toString();
     }
     

--- a/common/data/src/main/java/com/hashmapinc/server/common/data/kv/StringDataEntry.java
+++ b/common/data/src/main/java/com/hashmapinc/server/common/data/kv/StringDataEntry.java
@@ -29,8 +29,8 @@ public class StringDataEntry extends BasicKvEntry {
         this.value = value;
     }
 
-    public StringDataEntry(String key, String unit, String value) {
-        super(key, unit);
+    public StringDataEntry(String key, String unit, String sourceUnit, String value) {
+        super(key, unit, sourceUnit);
         this.value = value;
     }
 
@@ -71,6 +71,7 @@ public class StringDataEntry extends BasicKvEntry {
         return "StringDataEntry{"
                 + "value='" + getValueAsString() + '\'' +
                 ", unit=" + super.getUnit().orElse(null) +
+                ", sourceUnit=" + super.getSourceUnit().orElse(null) +
                 "} " + super.toString();
     }
     

--- a/common/data/src/main/java/com/hashmapinc/server/common/data/kv/StringDataEntry.java
+++ b/common/data/src/main/java/com/hashmapinc/server/common/data/kv/StringDataEntry.java
@@ -34,6 +34,11 @@ public class StringDataEntry extends BasicKvEntry {
         this.value = value;
     }
 
+    public StringDataEntry(String key, String sourceUnit, String value) {
+        super(key, sourceUnit);
+        this.value = value;
+    }
+
     @Override
     public DataType getDataType() {
         return DataType.STRING;

--- a/common/transport/src/main/java/com/hashmapinc/server/common/transport/adaptor/JsonConverter.java
+++ b/common/transport/src/main/java/com/hashmapinc/server/common/transport/adaptor/JsonConverter.java
@@ -172,9 +172,9 @@ public class JsonConverter {
         boolean unitPresent = false;
         if (value.has(VALUE) && value.has("unit")){
             if(value.get(VALUE).getNodeType() == JsonNodeType.BOOLEAN){
-                result.add(new BooleanDataEntry(key, value.get("unit").asText(), value.get(VALUE).asBoolean()));
+                result.add(new BooleanDataEntry(key, value.get("unit").asText(), value.get("unit").asText(), value.get(VALUE).asBoolean()));
             }else if(value.get(VALUE).getNodeType() == JsonNodeType.STRING){
-                result.add(new StringDataEntry(key, value.get("unit").asText(), value.get(VALUE).asText()));
+                result.add(new StringDataEntry(key, value.get("unit").asText(), value.get("unit").asText(), value.get(VALUE).asText()));
             }else if(value.get(VALUE).getNodeType() == JsonNodeType.NUMBER){
                 parseNumericValueAndConvertToSi(result, key, value.get("unit").asText(), value.get(VALUE));
             }
@@ -200,12 +200,12 @@ public class JsonConverter {
         Quantity quantity;
         if (value.asText().contains(".")) {
             quantity = UnitConverter.convertToSiUnit(new Quantity(value.asDouble() , unit));
-            result.add(new DoubleDataEntry(key, quantity.getUnit(), quantity.getValue()));
+            result.add(new DoubleDataEntry(key, quantity.getUnit(), unit, quantity.getValue()));
         } else {
             try {
                 long longValue = value.asLong();
                 quantity = UnitConverter.convertToSiUnit(new Quantity(((Long)longValue).doubleValue(), unit));
-                result.add(new DoubleDataEntry(key, quantity.getUnit(), quantity.getValue()));
+                result.add(new DoubleDataEntry(key, quantity.getUnit(), unit, quantity.getValue()));
             } catch (NumberFormatException e) {
                 throw new JsonSyntaxException("Big integer values are not supported!");
             }

--- a/common/transport/src/main/java/com/hashmapinc/server/common/transport/adaptor/JsonConverter.java
+++ b/common/transport/src/main/java/com/hashmapinc/server/common/transport/adaptor/JsonConverter.java
@@ -172,9 +172,9 @@ public class JsonConverter {
         boolean unitPresent = false;
         if (value.has(VALUE) && value.has("unit")){
             if(value.get(VALUE).getNodeType() == JsonNodeType.BOOLEAN){
-                result.add(new BooleanDataEntry(key, value.get("unit").asText(), value.get("unit").asText(), value.get(VALUE).asBoolean()));
+                result.add(new BooleanDataEntry(key, value.get("unit").asText(), value.get(VALUE).asBoolean()));
             }else if(value.get(VALUE).getNodeType() == JsonNodeType.STRING){
-                result.add(new StringDataEntry(key, value.get("unit").asText(), value.get("unit").asText(), value.get(VALUE).asText()));
+                result.add(new StringDataEntry(key, value.get("unit").asText(), value.get(VALUE).asText()));
             }else if(value.get(VALUE).getNodeType() == JsonNodeType.NUMBER){
                 parseNumericValueAndConvertToSi(result, key, value.get("unit").asText(), value.get(VALUE));
             }

--- a/common/transport/src/main/java/com/hashmapinc/server/common/transport/adaptor/JsonConverter.java
+++ b/common/transport/src/main/java/com/hashmapinc/server/common/transport/adaptor/JsonConverter.java
@@ -196,16 +196,16 @@ public class JsonConverter {
         }
     }
 
-    private static void parseNumericValueAndConvertToSi(List<KvEntry> result, String key, String unit, JsonNode value) {
+    private static void parseNumericValueAndConvertToSi(List<KvEntry> result, String key, String sourceUnit, JsonNode value) {
         Quantity quantity;
         if (value.asText().contains(".")) {
-            quantity = UnitConverter.convertToSiUnit(new Quantity(value.asDouble() , unit));
-            result.add(new DoubleDataEntry(key, quantity.getUnit(), unit, quantity.getValue()));
+            quantity = UnitConverter.convertToSiUnit(new Quantity(value.asDouble() , sourceUnit));
+            result.add(new DoubleDataEntry(key, quantity.getUnit(), sourceUnit, quantity.getValue()));
         } else {
             try {
                 long longValue = value.asLong();
-                quantity = UnitConverter.convertToSiUnit(new Quantity(((Long)longValue).doubleValue(), unit));
-                result.add(new DoubleDataEntry(key, quantity.getUnit(), unit, quantity.getValue()));
+                quantity = UnitConverter.convertToSiUnit(new Quantity(((Long)longValue).doubleValue(), sourceUnit));
+                result.add(new DoubleDataEntry(key, quantity.getUnit(), sourceUnit, quantity.getValue()));
             } catch (NumberFormatException e) {
                 throw new JsonSyntaxException("Big integer values are not supported!");
             }

--- a/dao/src/it/java/com/hashmapinc/server/HybridIntegrationTestSuite.java
+++ b/dao/src/it/java/com/hashmapinc/server/HybridIntegrationTestSuite.java
@@ -42,7 +42,7 @@ public class HybridIntegrationTestSuite {
             Arrays.asList("sql/hsql/schema.sql", "sql/system-data.sql"),
             "sql/drop-all-tables.sql",
             "sql-test.properties",
-            Collections.emptyList());
+            Arrays.asList("sql/hsql/upgrade/1.sql"));
 
     public static CustomCassandraCQLUnit cassandraUnit =
             new CustomCassandraCQLUnit(getDataSets(),
@@ -57,7 +57,9 @@ public class HybridIntegrationTestSuite {
     }
 
     private static List<CustomCassandraCQLUnit.NamedDataset> getUpgradeDataSets(){
-        return Collections.emptyList();
+        List<CustomCassandraCQLUnit.NamedDataset> dataSets = new ArrayList<>();
+        dataSets.add(new CustomCassandraCQLUnit.NamedDataset("1.cql", new ClassPathCQLDataSet("cassandra/upgrade/1.cql" , false, false)));
+        return dataSets;
     }
 
 

--- a/dao/src/it/java/com/hashmapinc/server/SqlIntegrationTestSuite.java
+++ b/dao/src/it/java/com/hashmapinc/server/SqlIntegrationTestSuite.java
@@ -38,5 +38,5 @@ public class SqlIntegrationTestSuite {
             Arrays.asList("sql/hsql/schema.sql", "sql/system-data.sql"),
             "sql/drop-all-tables.sql",
             "sql-test.properties",
-            Collections.emptyList());
+            Arrays.asList("sql/hsql/upgrade/1.sql"));
 }

--- a/dao/src/it/java/com/hashmapinc/server/dao/service/BaseTenantServiceTest.java
+++ b/dao/src/it/java/com/hashmapinc/server/dao/service/BaseTenantServiceTest.java
@@ -207,9 +207,9 @@ public abstract class BaseTenantServiceTest extends AbstractServiceTest {
     @Test
     public void testSaveUserUnitSystem() {
         TenantId tenantId = new TenantId(UUIDConverter.fromString("1e7461259eab8808080808080808080"));
-        tenantService.saveUnitSystem("UK", tenantId);
+        tenantService.saveUnitSystem("English", tenantId);
         String unitSystem = tenantService.findUnitSystemByTenantId(tenantId);
-        Assert.assertEquals("{\"unit_system\":\"UK\"}", unitSystem);
+        Assert.assertEquals("{\"unit_system\":\"English\"}", unitSystem);
         Assert.assertNotNull(unitSystem);
         tenantService.deleteUnitSystemByTenantId(tenantId);
     }
@@ -217,10 +217,10 @@ public abstract class BaseTenantServiceTest extends AbstractServiceTest {
     @Test
     public void testFindUnitSystemByUserId() {
         TenantId tenantId = new TenantId(UUIDConverter.fromString("1e7461259eab8808080808080808080"));
-        tenantService.saveUnitSystem("UK", tenantId);
+        tenantService.saveUnitSystem("English", tenantId);
         String unitSystemByUserId = tenantService.findUnitSystemByTenantId(tenantId);
         Assert.assertNotNull(unitSystemByUserId);
-        Assert.assertEquals("{\"unit_system\":\"UK\"}", unitSystemByUserId);
+        Assert.assertEquals("{\"unit_system\":\"English\"}", unitSystemByUserId);
         tenantService.deleteUnitSystemByTenantId(tenantId);
     }
 
@@ -228,21 +228,21 @@ public abstract class BaseTenantServiceTest extends AbstractServiceTest {
     public void testFindUnitSystemByUserIdNotPresentShouldReturnSi() {
         String unitSystemByUserId = tenantService.findUnitSystemByTenantId(new TenantId(UUIDConverter.fromString("1e7461259eab8808080808080818181")));
         Assert.assertNotNull(unitSystemByUserId);
-        Assert.assertEquals("{\"unit_system\":\"SI\"}", unitSystemByUserId);
+        Assert.assertEquals("{\"unit_system\":\"Metric\"}", unitSystemByUserId);
     }
 
     @Test
     public void testUpdateUnitSystemByUserId() {
         TenantId tenantId = new TenantId(UUIDConverter.fromString("1e7461259eab8808080808081818181"));
-        tenantService.saveUnitSystem("UK", tenantId);
+        tenantService.saveUnitSystem("English", tenantId);
         String unitSystemByUserId = tenantService.findUnitSystemByTenantId(tenantId);
         Assert.assertNotNull(unitSystemByUserId);
-        Assert.assertEquals("{\"unit_system\":\"UK\"}", unitSystemByUserId);
+        Assert.assertEquals("{\"unit_system\":\"English\"}", unitSystemByUserId);
 
-        tenantService.saveUnitSystem("US", tenantId);
+        tenantService.saveUnitSystem("Canadian", tenantId);
         String updatedUnitSystem = tenantService.findUnitSystemByTenantId(tenantId);
         Assert.assertNotNull(updatedUnitSystem);
-        Assert.assertEquals("{\"unit_system\":\"US\"}", updatedUnitSystem);
+        Assert.assertEquals("{\"unit_system\":\"Canadian\"}", updatedUnitSystem);
         tenantService.deleteUnitSystemByTenantId(tenantId);
     }
 }

--- a/dao/src/it/java/com/hashmapinc/server/dao/service/BaseUnitConversionServiceTest.java
+++ b/dao/src/it/java/com/hashmapinc/server/dao/service/BaseUnitConversionServiceTest.java
@@ -17,6 +17,7 @@
 package com.hashmapinc.server.dao.service;
 
 import com.hashmapinc.tempus.model.Quantity;
+import com.hashmapinc.tempus.service.UnitSystem;
 import org.junit.Test;
 import org.junit.Assert;
 
@@ -81,5 +82,15 @@ public class BaseUnitConversionServiceTest extends AbstractServiceTest {
     public void getMemberUnitsForQuantityClassForMass() {
         Set masses = unitConversionService.getMemberUnitsForQuantityClass("mass");
         Assert.assertNotNull(masses);
+    }
+
+    @Test
+    public void getUnitForDogLegAngleGradient() {
+        Assert.assertEquals("deg/100ft", unitConversionService.getUnitFor("ENGLISH", "deg/30m"));
+    }
+
+    @Test
+    public void getUnitForMassPerTimePerArea() {
+        Assert.assertEquals("lbm/(ft2.s)", unitConversionService.getUnitFor("ENGLISH", "kg/(m2.s)"));
     }
 }

--- a/dao/src/it/java/com/hashmapinc/server/dao/service/attributes/BaseAttributesServiceTest.java
+++ b/dao/src/it/java/com/hashmapinc/server/dao/service/attributes/BaseAttributesServiceTest.java
@@ -100,12 +100,12 @@ public abstract class BaseAttributesServiceTest extends AbstractServiceTest {
     public void findAllWithUnit() throws Exception {
         DeviceId deviceId = new DeviceId(UUIDs.timeBased());
 
-        KvEntry attrAOldValue = new DoubleDataEntry("A", "m", 10.0);
-        AttributeKvEntry attrAOld = new BaseAttributeKvEntry(attrAOldValue, 42L);
-        KvEntry attrANewValue = new DoubleDataEntry("A", "m", 634.2);
-        AttributeKvEntry attrANew = new BaseAttributeKvEntry(attrANewValue, 73L);
-        KvEntry attrBNewValue = new DoubleDataEntry("B", "kg", 93.1);
-        AttributeKvEntry attrBNew = new BaseAttributeKvEntry(attrBNewValue, 73L);
+        KvEntry attrAOldValue = new DoubleDataEntry("A", "m",10.0);
+        AttributeKvEntry attrAOld = new BaseAttributeKvEntry(attrAOldValue,42L);
+        KvEntry attrANewValue = new DoubleDataEntry("A", "m",634.2);
+        AttributeKvEntry attrANew = new BaseAttributeKvEntry(attrANewValue,73L);
+        KvEntry attrBNewValue = new DoubleDataEntry("B", "kg",93.1);
+        AttributeKvEntry attrBNew = new BaseAttributeKvEntry(attrBNewValue,73L);
 
         attributesService.save(deviceId, DataConstants.CLIENT_SCOPE, Collections.singletonList(attrAOld)).get();
         attributesService.save(deviceId, DataConstants.CLIENT_SCOPE, Collections.singletonList(attrANew)).get();

--- a/dao/src/it/java/com/hashmapinc/server/dao/service/attributes/BaseAttributesServiceTest.java
+++ b/dao/src/it/java/com/hashmapinc/server/dao/service/attributes/BaseAttributesServiceTest.java
@@ -100,11 +100,11 @@ public abstract class BaseAttributesServiceTest extends AbstractServiceTest {
     public void findAllWithUnit() throws Exception {
         DeviceId deviceId = new DeviceId(UUIDs.timeBased());
 
-        KvEntry attrAOldValue = new DoubleDataEntry("A", "m",10.0);
+        KvEntry attrAOldValue = new DoubleDataEntry("A", "m", "m",10.0);
         AttributeKvEntry attrAOld = new BaseAttributeKvEntry(attrAOldValue, 42L);
-        KvEntry attrANewValue = new DoubleDataEntry("A", "m",634.2);
+        KvEntry attrANewValue = new DoubleDataEntry("A", "m", "m", 634.2);
         AttributeKvEntry attrANew = new BaseAttributeKvEntry(attrANewValue, 73L);
-        KvEntry attrBNewValue = new DoubleDataEntry("B", "kg",93.1);
+        KvEntry attrBNewValue = new DoubleDataEntry("B", "kg", "kg",93.1);
         AttributeKvEntry attrBNew = new BaseAttributeKvEntry(attrBNewValue, 73L);
 
         attributesService.save(deviceId, DataConstants.CLIENT_SCOPE, Collections.singletonList(attrAOld)).get();

--- a/dao/src/it/java/com/hashmapinc/server/dao/service/attributes/BaseAttributesServiceTest.java
+++ b/dao/src/it/java/com/hashmapinc/server/dao/service/attributes/BaseAttributesServiceTest.java
@@ -100,11 +100,11 @@ public abstract class BaseAttributesServiceTest extends AbstractServiceTest {
     public void findAllWithUnit() throws Exception {
         DeviceId deviceId = new DeviceId(UUIDs.timeBased());
 
-        KvEntry attrAOldValue = new DoubleDataEntry("A", "m", "m",10.0);
+        KvEntry attrAOldValue = new DoubleDataEntry("A", "m", 10.0);
         AttributeKvEntry attrAOld = new BaseAttributeKvEntry(attrAOldValue, 42L);
-        KvEntry attrANewValue = new DoubleDataEntry("A", "m", "m", 634.2);
+        KvEntry attrANewValue = new DoubleDataEntry("A", "m", 634.2);
         AttributeKvEntry attrANew = new BaseAttributeKvEntry(attrANewValue, 73L);
-        KvEntry attrBNewValue = new DoubleDataEntry("B", "kg", "kg",93.1);
+        KvEntry attrBNewValue = new DoubleDataEntry("B", "kg", 93.1);
         AttributeKvEntry attrBNew = new BaseAttributeKvEntry(attrBNewValue, 73L);
 
         attributesService.save(deviceId, DataConstants.CLIENT_SCOPE, Collections.singletonList(attrAOld)).get();

--- a/dao/src/it/java/com/hashmapinc/server/dao/service/depthseries/BaseDepthseriesServiceTest.java
+++ b/dao/src/it/java/com/hashmapinc/server/dao/service/depthseries/BaseDepthseriesServiceTest.java
@@ -46,9 +46,9 @@ public class BaseDepthseriesServiceTest extends AbstractServiceTest {
     JsonParser parser = new JsonParser();
     KvEntry stringKvEntry = new StringDataEntry(STRING_KEY, "value");
     KvEntry longKvEntry = new LongDataEntry(LONG_KEY, Long.MAX_VALUE);
-    KvEntry longKvEntryWithUnit = new LongDataEntry(LONG_KEY, "mm", "mm", Long.MAX_VALUE);
+    KvEntry longKvEntryWithUnit = new LongDataEntry(LONG_KEY, "mm", Long.MAX_VALUE);
     KvEntry doubleKvEntry = new DoubleDataEntry(DOUBLE_KEY, Double.MAX_VALUE);
-    KvEntry doubleKvEntryWithUnit = new DoubleDataEntry(DOUBLE_KEY, "cm", "cm", Double.MAX_VALUE);
+    KvEntry doubleKvEntryWithUnit = new DoubleDataEntry(DOUBLE_KEY, "cm", Double.MAX_VALUE);
     KvEntry booleanKvEntry = new BooleanDataEntry(BOOLEAN_KEY, Boolean.TRUE);
     KvEntry jsonKvEntry = new JsonDataEntry(JSON_KEY, parser.parse("{\"tag\": \"value\"}").getAsJsonObject());
 

--- a/dao/src/it/java/com/hashmapinc/server/dao/service/depthseries/BaseDepthseriesServiceTest.java
+++ b/dao/src/it/java/com/hashmapinc/server/dao/service/depthseries/BaseDepthseriesServiceTest.java
@@ -46,9 +46,9 @@ public class BaseDepthseriesServiceTest extends AbstractServiceTest {
     JsonParser parser = new JsonParser();
     KvEntry stringKvEntry = new StringDataEntry(STRING_KEY, "value");
     KvEntry longKvEntry = new LongDataEntry(LONG_KEY, Long.MAX_VALUE);
-    KvEntry longKvEntryWithUnit = new LongDataEntry(LONG_KEY, "mm", Long.MAX_VALUE);
+    KvEntry longKvEntryWithUnit = new LongDataEntry(LONG_KEY, "mm", "mm", Long.MAX_VALUE);
     KvEntry doubleKvEntry = new DoubleDataEntry(DOUBLE_KEY, Double.MAX_VALUE);
-    KvEntry doubleKvEntryWithUnit = new DoubleDataEntry(DOUBLE_KEY, "cm", Double.MAX_VALUE);
+    KvEntry doubleKvEntryWithUnit = new DoubleDataEntry(DOUBLE_KEY, "cm", "cm", Double.MAX_VALUE);
     KvEntry booleanKvEntry = new BooleanDataEntry(BOOLEAN_KEY, Boolean.TRUE);
     KvEntry jsonKvEntry = new JsonDataEntry(JSON_KEY, parser.parse("{\"tag\": \"value\"}").getAsJsonObject());
 

--- a/dao/src/it/java/com/hashmapinc/server/dao/service/timeseries/BaseTimeseriesServiceTest.java
+++ b/dao/src/it/java/com/hashmapinc/server/dao/service/timeseries/BaseTimeseriesServiceTest.java
@@ -50,9 +50,9 @@ public abstract class BaseTimeseriesServiceTest extends AbstractServiceTest {
     JsonParser parser = new JsonParser();
     KvEntry stringKvEntry = new StringDataEntry(STRING_KEY, "value");
     KvEntry longKvEntry = new LongDataEntry(LONG_KEY, Long.MAX_VALUE);
-    KvEntry longKvEntryWithUnit = new LongDataEntry(LONG_KEY, "mm", "mm", Long.MAX_VALUE);
+    KvEntry longKvEntryWithUnit = new LongDataEntry(LONG_KEY, "mm", Long.MAX_VALUE);
     KvEntry doubleKvEntry = new DoubleDataEntry(DOUBLE_KEY, Double.MAX_VALUE);
-    KvEntry doubleKvEntryWithUnit = new DoubleDataEntry(DOUBLE_KEY, "cm", "cm", Double.MAX_VALUE);
+    KvEntry doubleKvEntryWithUnit = new DoubleDataEntry(DOUBLE_KEY, "cm", Double.MAX_VALUE);
     KvEntry booleanKvEntry = new BooleanDataEntry(BOOLEAN_KEY, Boolean.TRUE);
     KvEntry jsonKvEntry = new JsonDataEntry(JSON_KEY, parser.parse("{\"tag\": \"value\"}").getAsJsonObject());
 

--- a/dao/src/it/java/com/hashmapinc/server/dao/service/timeseries/BaseTimeseriesServiceTest.java
+++ b/dao/src/it/java/com/hashmapinc/server/dao/service/timeseries/BaseTimeseriesServiceTest.java
@@ -50,9 +50,9 @@ public abstract class BaseTimeseriesServiceTest extends AbstractServiceTest {
     JsonParser parser = new JsonParser();
     KvEntry stringKvEntry = new StringDataEntry(STRING_KEY, "value");
     KvEntry longKvEntry = new LongDataEntry(LONG_KEY, Long.MAX_VALUE);
-    KvEntry longKvEntryWithUnit = new LongDataEntry(LONG_KEY, "mm", Long.MAX_VALUE);
+    KvEntry longKvEntryWithUnit = new LongDataEntry(LONG_KEY, "mm", "mm", Long.MAX_VALUE);
     KvEntry doubleKvEntry = new DoubleDataEntry(DOUBLE_KEY, Double.MAX_VALUE);
-    KvEntry doubleKvEntryWithUnit = new DoubleDataEntry(DOUBLE_KEY, "cm", Double.MAX_VALUE);
+    KvEntry doubleKvEntryWithUnit = new DoubleDataEntry(DOUBLE_KEY, "cm", "cm", Double.MAX_VALUE);
     KvEntry booleanKvEntry = new BooleanDataEntry(BOOLEAN_KEY, Boolean.TRUE);
     KvEntry jsonKvEntry = new JsonDataEntry(JSON_KEY, parser.parse("{\"tag\": \"value\"}").getAsJsonObject());
 

--- a/dao/src/main/java/com/hashmapinc/server/dao/attributes/CassandraBaseAttributesDao.java
+++ b/dao/src/main/java/com/hashmapinc/server/dao/attributes/CassandraBaseAttributesDao.java
@@ -130,6 +130,7 @@ public class CassandraBaseAttributesDao extends CassandraAbstractAsyncDao implem
             stmt.setToNull(9);
         }
         stmt.setString(10, attribute.getUnit().orElse(null));
+        stmt.setString(11, attribute.getSourceUnit().orElse(null));
         log.trace("Generated save stmt [{}] for entityId {} and attributeType {} and attribute", stmt, entityId, attributeType, attribute);
         return getFuture(executeAsyncWrite(stmt), rs -> null);
     }
@@ -215,8 +216,9 @@ public class CassandraBaseAttributesDao extends CassandraAbstractAsyncDao implem
                     "," + ModelConstants.DOUBLE_VALUE_COLUMN +
                     "," + ModelConstants.JSON_VALUE_COLUMN +
                     "," + ModelConstants.UNIT_COLUMN +
+                    "," + ModelConstants.SOURCE_UNIT_COLUMN +
                     ")" +
-                    " VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+                    " VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
         }
         return saveStmt;
     }

--- a/dao/src/main/java/com/hashmapinc/server/dao/depthseries/CassandraBaseDepthSeriesDao.java
+++ b/dao/src/main/java/com/hashmapinc/server/dao/depthseries/CassandraBaseDepthSeriesDao.java
@@ -257,10 +257,11 @@ public class CassandraBaseDepthSeriesDao extends CassandraAbstractAsyncDao imple
                 .setString(2, dsKvEntry.getKey())
                 .setDouble(3, partition)
                 .setDouble(4, dsKvEntry.getDs())
-                .setString(6, dsKvEntry.getUnit().orElse(null));
+                .setString(6, dsKvEntry.getUnit().orElse(null))
+                .setString(7, dsKvEntry.getSourceUnit().orElse(null));
         addValue(dsKvEntry, stmt, 5);
         if (ttl > 0) {
-            stmt.setInt(7, (int) ttl);
+            stmt.setInt(8, (int) ttl);
         }
         return getFuture(executeAsyncWrite(stmt), rs -> null);
     }
@@ -288,7 +289,8 @@ public class CassandraBaseDepthSeriesDao extends CassandraAbstractAsyncDao imple
                 .setUUID(1, entityId.getId())
                 .setString(2, dsKvEntry.getKey())
                 .setDouble(3, dsKvEntry.getDs())
-                .setString(5, dsKvEntry.getUnit().orElse(null));
+                .setString(5, dsKvEntry.getUnit().orElse(null))
+                .setString(6, dsKvEntry.getSourceUnit().orElse(null));
         addValue(dsKvEntry, stmt, 4);
         return getFuture(executeAsyncWrite(stmt), rs -> null);
     }
@@ -407,17 +409,18 @@ public class CassandraBaseDepthSeriesDao extends CassandraAbstractAsyncDao imple
 
     public static KvEntry toKvEntry(Row row, String key) {
         String unit = row.get(ModelConstants.UNIT_COLUMN, String.class);
+        String sourceUnit = row.get(ModelConstants.SOURCE_UNIT_COLUMN, String.class);
         if (row.get(ModelConstants.STRING_VALUE_COLUMN, String.class) != null) {
-            return new StringDataEntry(key, unit, row.get(ModelConstants.STRING_VALUE_COLUMN, String.class));
+            return new StringDataEntry(key, unit, sourceUnit, row.get(ModelConstants.STRING_VALUE_COLUMN, String.class));
         }
         if (row.get(ModelConstants.LONG_VALUE_COLUMN, Long.class) != null) {
-            return new LongDataEntry(key, unit, row.get(ModelConstants.LONG_VALUE_COLUMN, Long.class));
+            return new LongDataEntry(key, unit, sourceUnit, row.get(ModelConstants.LONG_VALUE_COLUMN, Long.class));
         }
         if (row.get(ModelConstants.DOUBLE_VALUE_COLUMN, Double.class) != null) {
-            return new DoubleDataEntry(key, unit, row.get(ModelConstants.DOUBLE_VALUE_COLUMN, Double.class));
+            return new DoubleDataEntry(key, unit, sourceUnit, row.get(ModelConstants.DOUBLE_VALUE_COLUMN, Double.class));
         }
         if (row.get(ModelConstants.BOOLEAN_VALUE_COLUMN, Boolean.class) != null) {
-            return new BooleanDataEntry(key, unit, row.get(ModelConstants.BOOLEAN_VALUE_COLUMN, Boolean.class));
+            return new BooleanDataEntry(key, unit, sourceUnit, row.get(ModelConstants.BOOLEAN_VALUE_COLUMN, Boolean.class));
         }
         if (row.get(ModelConstants.JSON_VALUE_COLUMN, JsonNode.class) != null) {
             return new JsonDataEntry(key, row.get(ModelConstants.JSON_VALUE_COLUMN, JsonNode.class));
@@ -449,8 +452,9 @@ public class CassandraBaseDepthSeriesDao extends CassandraAbstractAsyncDao imple
                         "," + ModelConstants.PARTITION_COLUMN +
                         "," + ModelConstants.DS_COLUMN +
                         "," + getColumnName(type) +
-                        "," + ModelConstants.UNIT_COLUMN + ")" +
-                        " VALUES(?, ?, ?, ?, ?, ?, ?)");
+                        "," + ModelConstants.UNIT_COLUMN +
+                        "," + ModelConstants.SOURCE_UNIT_COLUMN + ")" +
+                        " VALUES(?, ?, ?, ?, ?, ?, ?, ?)");
             }
         }
         return saveStmts[dataType.ordinal()];
@@ -467,8 +471,9 @@ public class CassandraBaseDepthSeriesDao extends CassandraAbstractAsyncDao imple
                         "," + ModelConstants.PARTITION_COLUMN +
                         "," + ModelConstants.DS_COLUMN +
                         "," + getColumnName(type) +
-                        "," + ModelConstants.UNIT_COLUMN + ")" +
-                        " VALUES(?, ?, ?, ?, ?, ?, ?) USING TTL ?");
+                        "," + ModelConstants.UNIT_COLUMN +
+                        "," + ModelConstants.SOURCE_UNIT_COLUMN + ")" +
+                        " VALUES(?, ?, ?, ?, ?, ?, ?, ?) USING TTL ?");
             }
         }
         return saveTtlStmts[dataType.ordinal()];
@@ -508,8 +513,9 @@ public class CassandraBaseDepthSeriesDao extends CassandraAbstractAsyncDao imple
                         "," + ModelConstants.KEY_COLUMN +
                         "," + ModelConstants.DS_COLUMN +
                         "," + getColumnName(type) +
-                        "," + ModelConstants.UNIT_COLUMN + ")" +
-                        " VALUES(?, ?, ?, ?, ?, ?)");
+                        "," + ModelConstants.UNIT_COLUMN +
+                        "," + ModelConstants.SOURCE_UNIT_COLUMN + ")" +
+                        " VALUES(?, ?, ?, ?, ?, ?, ?)");
             }
         }
         return latestInsertStmts[dataType.ordinal()];
@@ -551,7 +557,8 @@ public class CassandraBaseDepthSeriesDao extends CassandraAbstractAsyncDao imple
                     ModelConstants.LONG_VALUE_COLUMN + "," +
                     ModelConstants.DOUBLE_VALUE_COLUMN + "," +
                     ModelConstants.JSON_VALUE_COLUMN + "," +
-                    ModelConstants.UNIT_COLUMN + " " +
+                    ModelConstants.UNIT_COLUMN + "," +
+                    ModelConstants.SOURCE_UNIT_COLUMN + " " +
                     "FROM " + ModelConstants.DS_KV_LATEST_CF + " " +
                     "WHERE " + ModelConstants.ENTITY_TYPE_COLUMN + EQUAL_PLACEHOLDER +
                     "AND " + ModelConstants.ENTITY_ID_COLUMN + EQUAL_PLACEHOLDER +
@@ -570,7 +577,8 @@ public class CassandraBaseDepthSeriesDao extends CassandraAbstractAsyncDao imple
                     ModelConstants.LONG_VALUE_COLUMN + "," +
                     ModelConstants.DOUBLE_VALUE_COLUMN + "," +
                     ModelConstants.JSON_VALUE_COLUMN + "," +
-                    ModelConstants.UNIT_COLUMN + " " +
+                    ModelConstants.UNIT_COLUMN + "," +
+                    ModelConstants.SOURCE_UNIT_COLUMN + " " +
                     "FROM " + ModelConstants.DS_KV_LATEST_CF + " " +
                     "WHERE " + ModelConstants.ENTITY_TYPE_COLUMN + EQUAL_PLACEHOLDER +
                     "AND " + ModelConstants.ENTITY_ID_COLUMN + EQUAL_PLACEHOLDER);

--- a/dao/src/main/java/com/hashmapinc/server/dao/model/ModelConstants.java
+++ b/dao/src/main/java/com/hashmapinc/server/dao/model/ModelConstants.java
@@ -366,6 +366,7 @@ public class ModelConstants {
     public static final String TS_COLUMN = "ts";
     public static final String DS_COLUMN = "ds";
     public static final String UNIT_COLUMN = "unit";
+    public static final String SOURCE_UNIT_COLUMN = "source_unit";
 
 
     /**

--- a/dao/src/main/java/com/hashmapinc/server/dao/model/sql/AttributeKvEntity.java
+++ b/dao/src/main/java/com/hashmapinc/server/dao/model/sql/AttributeKvEntity.java
@@ -75,17 +75,20 @@ public class AttributeKvEntity implements ToData<AttributeKvEntry>, Serializable
     @Column(name = ModelConstants.UNIT_COLUMN)
     private String unit;
 
+    @Column(name = ModelConstants.SOURCE_UNIT_COLUMN)
+    private String sourceUnit;
+
     @Override
     public AttributeKvEntry toData() {
         KvEntry kvEntry = null;
         if (strValue != null) {
-            kvEntry = new StringDataEntry(attributeKey, unit, strValue);
+            kvEntry = new StringDataEntry(attributeKey, unit, sourceUnit, strValue);
         } else if (booleanValue != null) {
-            kvEntry = new BooleanDataEntry(attributeKey, unit, booleanValue);
+            kvEntry = new BooleanDataEntry(attributeKey, unit, sourceUnit, booleanValue);
         } else if (doubleValue != null) {
-            kvEntry = new DoubleDataEntry(attributeKey, unit, doubleValue);
+            kvEntry = new DoubleDataEntry(attributeKey, unit, sourceUnit, doubleValue);
         } else if (longValue != null) {
-            kvEntry = new LongDataEntry(attributeKey, unit, longValue);
+            kvEntry = new LongDataEntry(attributeKey, unit, sourceUnit, longValue);
         } else if (jsonValue != null) {
             kvEntry = new JsonDataEntry(attributeKey, jsonValue);
         }

--- a/dao/src/main/java/com/hashmapinc/server/dao/model/sql/DsKvEntity.java
+++ b/dao/src/main/java/com/hashmapinc/server/dao/model/sql/DsKvEntity.java
@@ -107,17 +107,20 @@ public final class DsKvEntity implements ToData<DsKvEntry> {
     @Column(name = UNIT_COLUMN)
     private String unit;
 
+    @Column(name = SOURCE_UNIT_COLUMN)
+    private String sourceUnit;
+
     @Override
     public DsKvEntry toData() {
         KvEntry kvEntry = null;
         if (strValue != null) {
-            kvEntry = new StringDataEntry(key, unit, strValue);
+            kvEntry = new StringDataEntry(key, unit, sourceUnit, strValue);
         } else if (longValue != null) {
-            kvEntry = new LongDataEntry(key, unit, longValue);
+            kvEntry = new LongDataEntry(key, unit, sourceUnit, longValue);
         } else if (doubleValue != null) {
-            kvEntry = new DoubleDataEntry(key, unit, doubleValue);
+            kvEntry = new DoubleDataEntry(key, unit, sourceUnit, doubleValue);
         } else if (booleanValue != null) {
-            kvEntry = new BooleanDataEntry(key, unit, booleanValue);
+            kvEntry = new BooleanDataEntry(key, unit, sourceUnit, booleanValue);
         } else if (jsonValue != null){
             kvEntry = new JsonDataEntry(key, jsonValue);
         }

--- a/dao/src/main/java/com/hashmapinc/server/dao/model/sql/DsKvLatestEntity.java
+++ b/dao/src/main/java/com/hashmapinc/server/dao/model/sql/DsKvLatestEntity.java
@@ -71,17 +71,20 @@ public final class DsKvLatestEntity implements ToData<DsKvEntry> {
     @Column(name = UNIT_COLUMN)
     private String unit;
 
+    @Column(name = SOURCE_UNIT_COLUMN)
+    private String sourceUnit;
+
     @Override
     public DsKvEntry toData() {
         KvEntry kvEntry = null;
         if (strValue != null) {
-            kvEntry = new StringDataEntry(key, unit, strValue);
+            kvEntry = new StringDataEntry(key, unit, sourceUnit, strValue);
         } else if (longValue != null) {
-            kvEntry = new LongDataEntry(key, unit, longValue);
+            kvEntry = new LongDataEntry(key, unit, sourceUnit, longValue);
         } else if (doubleValue != null) {
-            kvEntry = new DoubleDataEntry(key, unit, doubleValue);
+            kvEntry = new DoubleDataEntry(key, unit, sourceUnit, doubleValue);
         } else if (booleanValue != null) {
-            kvEntry = new BooleanDataEntry(key, unit, booleanValue);
+            kvEntry = new BooleanDataEntry(key, unit, sourceUnit, booleanValue);
         } else if (jsonValue != null) {
             kvEntry = new JsonDataEntry(key, jsonValue);
         }

--- a/dao/src/main/java/com/hashmapinc/server/dao/model/sql/TsKvEntity.java
+++ b/dao/src/main/java/com/hashmapinc/server/dao/model/sql/TsKvEntity.java
@@ -107,17 +107,20 @@ public final class TsKvEntity implements ToData<TsKvEntry> {
     @Column(name = UNIT_COLUMN)
     private String unit;
 
+    @Column(name = SOURCE_UNIT_COLUMN)
+    private String sourceUnit;
+
     @Override
     public TsKvEntry toData() {
         KvEntry kvEntry = null;
         if (strValue != null) {
-            kvEntry = new StringDataEntry(key, unit, strValue);
+            kvEntry = new StringDataEntry(key, unit, sourceUnit, strValue);
         } else if (longValue != null) {
-            kvEntry = new LongDataEntry(key, unit, longValue);
+            kvEntry = new LongDataEntry(key, unit, sourceUnit, longValue);
         } else if (doubleValue != null) {
-            kvEntry = new DoubleDataEntry(key, unit, doubleValue);
+            kvEntry = new DoubleDataEntry(key, unit, sourceUnit, doubleValue);
         } else if (booleanValue != null) {
-            kvEntry = new BooleanDataEntry(key, unit, booleanValue);
+            kvEntry = new BooleanDataEntry(key, unit, sourceUnit, booleanValue);
         } else if (jsonValue != null) {
             kvEntry = new JsonDataEntry(key, jsonValue);
         }

--- a/dao/src/main/java/com/hashmapinc/server/dao/model/sql/TsKvLatestEntity.java
+++ b/dao/src/main/java/com/hashmapinc/server/dao/model/sql/TsKvLatestEntity.java
@@ -73,17 +73,20 @@ public final class TsKvLatestEntity implements ToData<TsKvEntry> {
     @Column(name = ModelConstants.UNIT_COLUMN)
     private String unit;
 
+    @Column(name = ModelConstants.SOURCE_UNIT_COLUMN)
+    private String sourceUnit;
+
     @Override
     public TsKvEntry toData() {
         KvEntry kvEntry = null;
         if (strValue != null) {
-            kvEntry = new StringDataEntry(key, unit, strValue);
+            kvEntry = new StringDataEntry(key, unit, sourceUnit, strValue);
         } else if (longValue != null) {
-            kvEntry = new LongDataEntry(key, unit, longValue);
+            kvEntry = new LongDataEntry(key, unit, sourceUnit, longValue);
         } else if (doubleValue != null) {
-            kvEntry = new DoubleDataEntry(key, unit, doubleValue);
+            kvEntry = new DoubleDataEntry(key, unit, sourceUnit, doubleValue);
         } else if (booleanValue != null) {
-            kvEntry = new BooleanDataEntry(key, unit, booleanValue);
+            kvEntry = new BooleanDataEntry(key, unit, sourceUnit, booleanValue);
         } else if (jsonValue != null) {
             kvEntry = new JsonDataEntry(key, jsonValue);
         }

--- a/dao/src/main/java/com/hashmapinc/server/dao/sql/attributes/AttributeKvRepository.java
+++ b/dao/src/main/java/com/hashmapinc/server/dao/sql/attributes/AttributeKvRepository.java
@@ -33,7 +33,7 @@ public interface AttributeKvRepository extends CrudRepository<AttributeKvEntity,
                                                                            String entityId,
                                                                            String attributeType);
 
-    @Query("SELECT akv.lastUpdateTs, akv.attributeKey, akv.booleanValue, akv.strValue, akv.longValue, akv.doubleValue, akv.jsonValue, akv.unit FROM AttributeKvEntity akv WHERE akv.entityId = :entityId " +
+    @Query("SELECT akv.lastUpdateTs, akv.attributeKey, akv.booleanValue, akv.strValue, akv.longValue, akv.doubleValue, akv.jsonValue, akv.unit, akv.sourceUnit FROM AttributeKvEntity akv WHERE akv.entityId = :entityId " +
             "AND akv.entityType = :entityType ORDER BY akv.lastUpdateTs DESC")
     List<Object[]> findAllByEntityTypeAndEntityId(@Param("entityId") String entityId, @Param("entityType") EntityType entityType);
 }

--- a/dao/src/main/java/com/hashmapinc/server/dao/sql/attributes/JpaAttributeDao.java
+++ b/dao/src/main/java/com/hashmapinc/server/dao/sql/attributes/JpaAttributeDao.java
@@ -92,6 +92,7 @@ public class JpaAttributeDao extends JpaAbstractDaoListeningExecutorService impl
         entity.setBooleanValue(attribute.getBooleanValue().orElse(null));
         entity.setJsonValue(attribute.getJsonValue().orElse(null));
         entity.setUnit(attribute.getUnit().orElse(null));
+        entity.setSourceUnit(attribute.getSourceUnit().orElse(null));
         return service.submit(() -> {
             attributeKvRepository.save(entity);
             return null;

--- a/dao/src/main/java/com/hashmapinc/server/dao/sql/depthseries/DsKvRepository.java
+++ b/dao/src/main/java/com/hashmapinc/server/dao/sql/depthseries/DsKvRepository.java
@@ -53,7 +53,7 @@ public interface DsKvRepository extends CrudRepository<DsKvEntity, DsKvComposite
                                           @Param("endDs") Double endDs);
 
 
-    @Query("SELECT dskv.ds, dskv.key, dskv.booleanValue, dskv.strValue, dskv.longValue, dskv.doubleValue, dskv.jsonValue, dskv.unit FROM DsKvEntity dskv WHERE dskv.entityId = :entityId " +
+    @Query("SELECT dskv.ds, dskv.key, dskv.booleanValue, dskv.strValue, dskv.longValue, dskv.doubleValue, dskv.jsonValue, dskv.unit, dskv.sourceUnit FROM DsKvEntity dskv WHERE dskv.entityId = :entityId " +
             "AND dskv.entityType = :entityType " +
             "AND dskv.ds >= :startDs AND dskv.ds <= :endDs ORDER BY dskv.ds DESC")
     List<Object[]> findSelected(@Param("entityId") String entityId,

--- a/dao/src/main/java/com/hashmapinc/server/dao/sql/depthseries/JpaDepthSeriesDao.java
+++ b/dao/src/main/java/com/hashmapinc/server/dao/sql/depthseries/JpaDepthSeriesDao.java
@@ -223,6 +223,7 @@ public class JpaDepthSeriesDao extends JpaAbstractDaoListeningExecutorService im
         entity.setBooleanValue(dsKvEntry.getBooleanValue().orElse(null));
         entity.setJsonValue(dsKvEntry.getJsonValue().orElse(null));
         entity.setUnit(dsKvEntry.getUnit().orElse(null));
+        entity.setSourceUnit(dsKvEntry.getSourceUnit().orElse(null));
         return service.submit(() -> {
             dsKvRepository.save(entity);
             return null;
@@ -247,6 +248,7 @@ public class JpaDepthSeriesDao extends JpaAbstractDaoListeningExecutorService im
         latestEntity.setBooleanValue(dsKvEntry.getBooleanValue().orElse(null));
         latestEntity.setJsonValue(dsKvEntry.getJsonValue().orElse(null));
         latestEntity.setUnit(dsKvEntry.getUnit().orElse(null));
+        latestEntity.setSourceUnit(dsKvEntry.getSourceUnit().orElse(null));
         return service.submit(() -> {
             dsKvLatestRepository.save(latestEntity);
             return null;

--- a/dao/src/main/java/com/hashmapinc/server/dao/sql/timeseries/JpaTimeseriesDao.java
+++ b/dao/src/main/java/com/hashmapinc/server/dao/sql/timeseries/JpaTimeseriesDao.java
@@ -261,6 +261,7 @@ public class JpaTimeseriesDao extends JpaAbstractDaoListeningExecutorService imp
         entity.setBooleanValue(tsKvEntry.getBooleanValue().orElse(null));
         entity.setJsonValue(tsKvEntry.getJsonValue().orElse(null));
         entity.setUnit(tsKvEntry.getUnit().orElse(null));
+        entity.setSourceUnit(tsKvEntry.getSourceUnit().orElse(null));
         log.trace("Saving entity: {}", entity);
         return insertService.submit(() -> {
             tsKvRepository.save(entity);
@@ -286,6 +287,7 @@ public class JpaTimeseriesDao extends JpaAbstractDaoListeningExecutorService imp
         latestEntity.setBooleanValue(tsKvEntry.getBooleanValue().orElse(null));
         latestEntity.setJsonValue(tsKvEntry.getJsonValue().orElse(null));
         latestEntity.setUnit(tsKvEntry.getUnit().orElse(null));
+        latestEntity.setSourceUnit(tsKvEntry.getSourceUnit().orElse(null));
         return insertService.submit(() -> {
             tsKvLatestRepository.save(latestEntity);
             return null;

--- a/dao/src/main/java/com/hashmapinc/server/dao/sql/timeseries/TsKvRepository.java
+++ b/dao/src/main/java/com/hashmapinc/server/dao/sql/timeseries/TsKvRepository.java
@@ -16,16 +16,15 @@
  */
 package com.hashmapinc.server.dao.sql.timeseries;
 
+import com.hashmapinc.server.common.data.EntityType;
+import com.hashmapinc.server.dao.model.sql.TsKvCompositeKey;
 import com.hashmapinc.server.dao.model.sql.TsKvEntity;
+import com.hashmapinc.server.dao.util.SqlDao;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.scheduling.annotation.Async;
-import com.hashmapinc.server.common.data.EntityType;
-import com.hashmapinc.server.dao.model.sql.TsKvCompositeKey;
-import com.hashmapinc.server.dao.util.SqlDao;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -43,7 +42,7 @@ public interface TsKvRepository extends CrudRepository<TsKvEntity, TsKvComposite
                                       @Param("endTs") long endTs,
                                       Pageable pageable);
 
-    @Query("SELECT tskv.ts, tskv.key, tskv.booleanValue, tskv.strValue, tskv.longValue, tskv.doubleValue, tskv.jsonValue, tskv.unit FROM TsKvEntity tskv WHERE tskv.entityId = :entityId " +
+    @Query("SELECT tskv.ts, tskv.key, tskv.booleanValue, tskv.strValue, tskv.longValue, tskv.doubleValue, tskv.jsonValue, tskv.unit, tskv.sourceUnit FROM TsKvEntity tskv WHERE tskv.entityId = :entityId " +
             "AND tskv.entityType = :entityType " +
             "AND tskv.ts >= :startTs AND tskv.ts <= :endTs ORDER BY tskv.ts DESC")
     List<Object[]> findSelected(@Param("entityId") String entityId,

--- a/dao/src/main/java/com/hashmapinc/server/dao/tenant/TenantServiceImpl.java
+++ b/dao/src/main/java/com/hashmapinc/server/dao/tenant/TenantServiceImpl.java
@@ -60,7 +60,7 @@ public class TenantServiceImpl extends AbstractEntityService implements TenantSe
 
     private static final String DEFAULT_TENANT_REGION = "Global";
     public static final String INCORRECT_TENANT_ID = "Incorrect tenantId ";
-    private static final String DEFAULT_UNIT_SYSTEM = "SI";
+    private static final String DEFAULT_UNIT_SYSTEM = "Metric";
 
     @Autowired
     private TenantDao tenantDao;

--- a/dao/src/main/java/com/hashmapinc/server/dao/timeseries/CassandraBaseTimeseriesDao.java
+++ b/dao/src/main/java/com/hashmapinc/server/dao/timeseries/CassandraBaseTimeseriesDao.java
@@ -340,10 +340,11 @@ public class CassandraBaseTimeseriesDao extends CassandraAbstractAsyncDao implem
                 .setString(2, tsKvEntry.getKey())
                 .setLong(3, partition)
                 .setLong(4, tsKvEntry.getTs())
-                .setString(6, tsKvEntry.getUnit().orElse(null));
+                .setString(6, tsKvEntry.getUnit().orElse(null))
+                .setString(7, tsKvEntry.getSourceUnit().orElse(null));
         addValue(tsKvEntry, stmt, 5);
         if (ttl > 0) {
-            stmt.setInt(7, (int) ttl);
+            stmt.setInt(8, (int) ttl);
         }
         return getFuture(executeAsyncWrite(stmt), rs -> null);
     }
@@ -371,7 +372,8 @@ public class CassandraBaseTimeseriesDao extends CassandraAbstractAsyncDao implem
                 .setUUID(1, entityId.getId())
                 .setString(2, tsKvEntry.getKey())
                 .setLong(3, tsKvEntry.getTs())
-                .setString(5, tsKvEntry.getUnit().orElse(null));
+                .setString(5, tsKvEntry.getUnit().orElse(null))
+                .setString(6, tsKvEntry.getSourceUnit().orElse(null));
         addValue(tsKvEntry, stmt, 4);
         return getFuture(executeAsyncWrite(stmt), rs -> null);
     }
@@ -415,17 +417,18 @@ public class CassandraBaseTimeseriesDao extends CassandraAbstractAsyncDao implem
 
     public static KvEntry toKvEntry(Row row, String key) {
         String unit = row.get(UNIT_COLUMN, String.class);
+        String sourceUnit = row.get(SOURCE_UNIT_COLUMN, String.class);
         if (row.get(STRING_VALUE_COLUMN, String.class) != null) {
-            return new StringDataEntry(key, unit, row.get(STRING_VALUE_COLUMN, String.class));
+            return new StringDataEntry(key, unit, sourceUnit, row.get(STRING_VALUE_COLUMN, String.class));
         }
         if (row.get(LONG_VALUE_COLUMN, Long.class) != null) {
-            return new LongDataEntry(key, unit, row.get(LONG_VALUE_COLUMN, Long.class));
+            return new LongDataEntry(key, unit, sourceUnit, row.get(LONG_VALUE_COLUMN, Long.class));
         }
         if (row.get(DOUBLE_VALUE_COLUMN, Double.class) != null) {
-            return new DoubleDataEntry(key, unit, row.get(DOUBLE_VALUE_COLUMN, Double.class));
+            return new DoubleDataEntry(key, unit, sourceUnit, row.get(DOUBLE_VALUE_COLUMN, Double.class));
         }
         if (row.get(BOOLEAN_VALUE_COLUMN, Boolean.class) != null) {
-            return new BooleanDataEntry(key, unit, row.get(BOOLEAN_VALUE_COLUMN, Boolean.class));
+            return new BooleanDataEntry(key, unit, sourceUnit, row.get(BOOLEAN_VALUE_COLUMN, Boolean.class));
         }
         if (row.get(JSON_VALUE_COLUMN, JsonNode.class) != null) {
             return new JsonDataEntry(key, row.get(JSON_VALUE_COLUMN, JsonNode.class));
@@ -465,8 +468,9 @@ public class CassandraBaseTimeseriesDao extends CassandraAbstractAsyncDao implem
                         "," + ModelConstants.PARTITION_COLUMN +
                         "," + TS_COLUMN +
                         "," + getColumnName(type) +
-                        "," + UNIT_COLUMN + ")" +
-                        " VALUES(?, ?, ?, ?, ?, ?, ?)");
+                        "," + UNIT_COLUMN +
+                        "," + SOURCE_UNIT_COLUMN +
+                        ")" + " VALUES(?, ?, ?, ?, ?, ?, ?, ?)");
             }
         }
         return saveStmts[dataType.ordinal()];
@@ -483,8 +487,9 @@ public class CassandraBaseTimeseriesDao extends CassandraAbstractAsyncDao implem
                         "," + ModelConstants.PARTITION_COLUMN +
                         "," + TS_COLUMN +
                         "," + getColumnName(type) +
-                        "," + UNIT_COLUMN + ")" +
-                        " VALUES(?, ?, ?, ?, ?, ?, ?) USING TTL ?");
+                        "," + UNIT_COLUMN +
+                        "," + SOURCE_UNIT_COLUMN +
+                        ")" + " VALUES(?, ?, ?, ?, ?, ?, ?, ?) USING TTL ?");
             }
         }
         return saveTtlStmts[dataType.ordinal()];
@@ -524,8 +529,9 @@ public class CassandraBaseTimeseriesDao extends CassandraAbstractAsyncDao implem
                         "," + KEY_COLUMN +
                         "," + TS_COLUMN +
                         "," + getColumnName(type) +
-                        "," + UNIT_COLUMN + ")" +
-                        " VALUES(?, ?, ?, ?, ?, ?)");
+                        "," + UNIT_COLUMN +
+                        "," + SOURCE_UNIT_COLUMN +
+                        ")" + " VALUES(?, ?, ?, ?, ?, ?, ?)");
             }
         }
         return latestInsertStmts[dataType.ordinal()];
@@ -567,7 +573,8 @@ public class CassandraBaseTimeseriesDao extends CassandraAbstractAsyncDao implem
                     ModelConstants.LONG_VALUE_COLUMN + "," +
                     ModelConstants.DOUBLE_VALUE_COLUMN + "," +
                     ModelConstants.JSON_VALUE_COLUMN + "," +
-                    ModelConstants.UNIT_COLUMN + " " +
+                    ModelConstants.UNIT_COLUMN + "," +
+                    ModelConstants.SOURCE_UNIT_COLUMN + " " +
                     "FROM " + ModelConstants.TS_KV_LATEST_CF + " " +
                     "WHERE " + ModelConstants.ENTITY_TYPE_COLUMN + EQUALS_PARAM +
                     "AND " + ModelConstants.ENTITY_ID_COLUMN + EQUALS_PARAM +
@@ -586,7 +593,8 @@ public class CassandraBaseTimeseriesDao extends CassandraAbstractAsyncDao implem
                     ModelConstants.LONG_VALUE_COLUMN + "," +
                     ModelConstants.DOUBLE_VALUE_COLUMN + "," +
                     ModelConstants.JSON_VALUE_COLUMN + "," +
-                    ModelConstants.UNIT_COLUMN + " " +
+                    ModelConstants.UNIT_COLUMN + "," +
+                    ModelConstants.SOURCE_UNIT_COLUMN + " " +
                     "FROM " + ModelConstants.TS_KV_LATEST_CF + " " +
                     "WHERE " + ModelConstants.ENTITY_TYPE_COLUMN + EQUALS_PARAM +
                     "AND " + ModelConstants.ENTITY_ID_COLUMN + EQUALS_PARAM);

--- a/dao/src/main/java/com/hashmapinc/server/dao/unitconversion/UnitConversionService.java
+++ b/dao/src/main/java/com/hashmapinc/server/dao/unitconversion/UnitConversionService.java
@@ -32,4 +32,6 @@ public interface UnitConversionService {
     Map<String, Set<String>> getMemberUnitsForAllQuantityClass();
 
     Set<String> getMemberUnitsForQuantityClass(String quantityClass);
+
+    String getUnitFor(String unitSystem, String sourceUnit);
 }

--- a/dao/src/main/java/com/hashmapinc/server/dao/unitconversion/UnitConversionServiceImpl.java
+++ b/dao/src/main/java/com/hashmapinc/server/dao/unitconversion/UnitConversionServiceImpl.java
@@ -20,9 +20,12 @@ import com.hashmapinc.tempus.UnitConvertorContext;
 import com.hashmapinc.tempus.exception.QuantityClassSetException;
 import com.hashmapinc.tempus.exception.UnitConvertorContextException;
 import com.hashmapinc.tempus.exception.UnitConvertorException;
+import com.hashmapinc.tempus.exception.UnitSystemSetException;
 import com.hashmapinc.tempus.model.Quantity;
 import com.hashmapinc.tempus.service.QuantityClassSetService;
 import com.hashmapinc.tempus.service.UnitConvertorService;
+import com.hashmapinc.tempus.service.UnitSystem;
+import com.hashmapinc.tempus.service.UnitSystemService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -38,11 +41,13 @@ public class UnitConversionServiceImpl implements UnitConversionService {
 
     private UnitConvertorService unitConvertorService;
     private QuantityClassSetService quantityClassSetService;
+    private UnitSystemService unitSystemService;
 
     @PostConstruct
     public void init() throws UnitConvertorContextException {
         unitConvertorService = UnitConvertorContext.getInstanceOfUnitConvertorService();
         quantityClassSetService = UnitConvertorContext.getInstanceOfQuantityClassSetService();
+        unitSystemService = UnitConvertorContext.getInstanceOfUnitSystemService();
     }
 
     @Override
@@ -93,5 +98,16 @@ public class UnitConversionServiceImpl implements UnitConversionService {
             log.info(ex.getMessage());
         }
         return Collections.emptySet();
+    }
+
+    @Override
+    public String getUnitFor(String unitSystem , String sourceUnit) {
+        UnitSystem system = UnitSystem.valueOf(unitSystem);
+        try {
+            return unitSystemService.getUnitFor(system, sourceUnit);
+        } catch (UnitSystemSetException e) {
+            log.debug(e.getMessage());
+        }
+        return sourceUnit;
     }
 }

--- a/dao/src/main/resources/cassandra/upgrade/1.cql
+++ b/dao/src/main/resources/cassandra/upgrade/1.cql
@@ -1,0 +1,22 @@
+--
+-- Copyright © 2016-2018 The Thingsboard Authors
+-- Modifications © 2017-2018 Hashmap, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+ALTER TABLE tempus.ts_kv_cf ADD source_unit text;
+ALTER TABLE tempus.ts_kv_latest_cf ADD source_unit text;
+ALTER TABLE tempus.ds_kv_cf ADD source_unit text;
+ALTER TABLE tempus.ds_kv_latest_cf ADD source_unit text;
+ALTER TABLE tempus.attributes_kv_cf ADD source_unit text;

--- a/dao/src/main/resources/sql/hsql/upgrade/1.sql
+++ b/dao/src/main/resources/sql/hsql/upgrade/1.sql
@@ -1,0 +1,22 @@
+--
+-- Copyright © 2016-2018 The Thingsboard Authors
+-- Modifications © 2017-2018 Hashmap, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+ALTER TABLE ts_kv ADD source_unit varchar;
+ALTER TABLE ts_kv_latest ADD source_unit varchar;
+ALTER TABLE ds_kv ADD source_unit varchar;
+ALTER TABLE ds_kv_latest ADD source_unit varchar;
+ALTER TABLE attribute_kv ADD source_unit varchar;

--- a/dao/src/main/resources/sql/postgres/upgrade/1.sql
+++ b/dao/src/main/resources/sql/postgres/upgrade/1.sql
@@ -1,0 +1,22 @@
+--
+-- Copyright © 2016-2018 The Thingsboard Authors
+-- Modifications © 2017-2018 Hashmap, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+ALTER TABLE ts_kv ADD source_unit varchar;
+ALTER TABLE ts_kv_latest ADD source_unit varchar;
+ALTER TABLE ds_kv ADD source_unit varchar;
+ALTER TABLE ds_kv_latest ADD source_unit varchar;
+ALTER TABLE attribute_kv ADD source_unit varchar;

--- a/extensions-api/src/main/java/com/hashmapinc/server/extensions/api/plugins/PluginContext.java
+++ b/extensions-api/src/main/java/com/hashmapinc/server/extensions/api/plugins/PluginContext.java
@@ -135,4 +135,14 @@ public interface PluginContext {
     ListenableFuture<List<EntityRelation>> findByFromAndType(EntityId from, String relationType);
 
     ListenableFuture<List<EntityRelation>> findByToAndType(EntityId from, String relationType);
+
+    /**
+     * Unit Conversion API
+     */
+    List<AttributeKvEntry> convertAttributeKvEntriesToUnitSystemByTenantId(List<AttributeKvEntry> attributeKvEntries, TenantId tenantId);
+
+    List<TsKvEntry> convertTsKvEntriesToUnitSystemByTenantId(List<TsKvEntry> tsKvEntries, TenantId tenantId);
+
+    List<DsKvEntry> convertDsKvEntriesToUnitSystemByTenantId(List<DsKvEntry> dsKvEntries, TenantId tenantId);
+
 }

--- a/extensions-api/src/main/java/com/hashmapinc/server/extensions/api/plugins/PluginContext.java
+++ b/extensions-api/src/main/java/com/hashmapinc/server/extensions/api/plugins/PluginContext.java
@@ -139,10 +139,6 @@ public interface PluginContext {
     /**
      * Unit Conversion API
      */
-    List<AttributeKvEntry> convertAttributeKvEntriesToUnitSystemByTenantId(List<AttributeKvEntry> attributeKvEntries, TenantId tenantId);
-
-    List<TsKvEntry> convertTsKvEntriesToUnitSystemByTenantId(List<TsKvEntry> tsKvEntries, TenantId tenantId);
-
-    List<DsKvEntry> convertDsKvEntriesToUnitSystemByTenantId(List<DsKvEntry> dsKvEntries, TenantId tenantId);
+    <E extends KvEntry, T extends E> List<E> convertKvEntriesToUnitSystemByTenantId(List<E> kvEntries, TenantId tenantId, Class<T> tClass);
 
 }

--- a/extensions-core/src/main/java/com/hashmapinc/server/extensions/core/plugin/telemetry/handlers/TelemetryRestMsgHandler.java
+++ b/extensions-core/src/main/java/com/hashmapinc/server/extensions/core/plugin/telemetry/handlers/TelemetryRestMsgHandler.java
@@ -278,10 +278,10 @@ public class TelemetryRestMsgHandler extends DefaultRestMsgHandler {
                     throw new IllegalArgumentException("No attributes data found in request body!");
                 }
                 TenantId tenantId = ctx.getSecurityCtx().orElseThrow(IllegalArgumentException::new).getTenantId();
-                List<AttributeKvEntry> attributeKvEntries = ctx.convertAttributeKvEntriesToUnitSystemByTenantId(attributes, tenantId);
                 ctx.saveAttributes(tenantId, entityId, scope, attributes, new PluginCallback<Void>() {
                     @Override
                     public void onSuccess(PluginContext ctx, Void value) {
+                        List<AttributeKvEntry> attributeKvEntries = ctx.convertKvEntriesToUnitSystemByTenantId(attributes, tenantId, BaseAttributeKvEntry.class);
                         ctx.logAttributesUpdated(msg.getSecurityCtx(), entityId, scope, attributes, null);
                         msg.getResponseHolder().setResult(new ResponseEntity<>(HttpStatus.OK));
                         subscriptionManager.onAttributesUpdateFromServer(ctx, entityId, scope, attributeKvEntries);
@@ -346,10 +346,10 @@ public class TelemetryRestMsgHandler extends DefaultRestMsgHandler {
             throw new IllegalArgumentException("No timeseries data found in request body!");
         }
         TenantId tenantId = ctx.getSecurityCtx().orElseThrow(IllegalArgumentException::new).getTenantId();
-        List<TsKvEntry> tsKvEntries = ctx.convertTsKvEntriesToUnitSystemByTenantId(entries, tenantId);
         ctx.saveTsData(tenantId, entityId, entries, ttl, new PluginCallback<Void>() {
             @Override
             public void onSuccess(PluginContext ctx, Void value) {
+                List<TsKvEntry> tsKvEntries = ctx.convertKvEntriesToUnitSystemByTenantId(entries, tenantId, BasicTsKvEntry.class);
                 msg.getResponseHolder().setResult(new ResponseEntity<>(HttpStatus.OK));
                 subscriptionManager.onTimeseriesUpdateFromServer(ctx, entityId, tsKvEntries);
             }

--- a/extensions-core/src/main/java/com/hashmapinc/server/extensions/core/plugin/telemetry/handlers/TelemetryRuleMsgHandler.java
+++ b/extensions-core/src/main/java/com/hashmapinc/server/extensions/core/plugin/telemetry/handlers/TelemetryRuleMsgHandler.java
@@ -33,7 +33,6 @@ import com.hashmapinc.server.extensions.core.plugin.telemetry.sub.SubscriptionTy
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Slf4j
 public class TelemetryRuleMsgHandler extends DefaultRuleMsgHandler {
@@ -94,7 +93,7 @@ public class TelemetryRuleMsgHandler extends DefaultRuleMsgHandler {
             public void onSuccess(PluginContext ctx, Void data) {
                 ctx.reply(new ResponsePluginToRuleMsg(msg.getUid(), tenantId, ruleId, BasicStatusCodeResponse.onSuccess(request.getMsgType(), request.getRequestId())));
                 subscriptionManager.onLocalSubscriptionUpdate(ctx, msg.getDeviceId(), SubscriptionType.TIMESERIES, s ->
-                        prepareSubscriptionUpdate(request, s)
+                        prepareSubscriptionUpdate(request, s, ctx, msg.getTenantId())
                 );
             }
 
@@ -106,7 +105,7 @@ public class TelemetryRuleMsgHandler extends DefaultRuleMsgHandler {
         });
     }
 
-    private List<TsKvEntry> prepareSubscriptionUpdate(TelemetryUploadRequest request, Subscription s) {
+    private List<TsKvEntry> prepareSubscriptionUpdate(TelemetryUploadRequest request, Subscription s, PluginContext ctx, TenantId tenantId) {
         List<TsKvEntry> subscriptionUpdate = new ArrayList<>();
         for (Map.Entry<Long, List<KvEntry>> entry : request.getData().entrySet()) {
             for (KvEntry kv : entry.getValue()) {
@@ -115,7 +114,7 @@ public class TelemetryRuleMsgHandler extends DefaultRuleMsgHandler {
                 }
             }
         }
-        return subscriptionUpdate;
+        return ctx.convertTsKvEntriesToUnitSystemByTenantId(subscriptionUpdate, tenantId);
     }
 
     @Override
@@ -133,7 +132,7 @@ public class TelemetryRuleMsgHandler extends DefaultRuleMsgHandler {
                 log.debug(" ctx.saveDsData On success");
                 ctx.reply(new ResponsePluginToRuleMsg(msg.getUid(), tenantId, ruleId, BasicStatusCodeResponse.onSuccess(request.getMsgType(), request.getRequestId())));
                 subscriptionManager.onLocalSubscriptionUpdateForDepth(ctx, msg.getDeviceId(), SubscriptionType.DEPTHSERIES, s ->
-                        prepareSubscriptionUpdate(request, s));
+                        prepareSubscriptionUpdate(request, s, ctx, msg.getTenantId()));
             }
 
             @Override
@@ -144,7 +143,7 @@ public class TelemetryRuleMsgHandler extends DefaultRuleMsgHandler {
         });
     }
 
-    private List<DsKvEntry> prepareSubscriptionUpdate(DepthTelemetryUploadRequest request, Subscription s){
+    private List<DsKvEntry> prepareSubscriptionUpdate(DepthTelemetryUploadRequest request, Subscription s, PluginContext ctx, TenantId tenantId){
         List<DsKvEntry> subscriptionUpdate = new ArrayList<>();
         for (Map.Entry<Double, List<KvEntry>> entry : request.getData().entrySet()) {
             for (KvEntry kv : entry.getValue()) {
@@ -153,21 +152,22 @@ public class TelemetryRuleMsgHandler extends DefaultRuleMsgHandler {
                 }
             }
         }
-        return subscriptionUpdate;
+        return ctx.convertDsKvEntriesToUnitSystemByTenantId(subscriptionUpdate, tenantId);
     }
 
     @Override
     public void handleUpdateAttributesRequest(PluginContext ctx, TenantId tenantId, RuleId ruleId, UpdateAttributesRequestRuleToPluginMsg msg) {
         UpdateAttributesRequest request = msg.getPayload();
-        ctx.saveAttributes(msg.getTenantId(), msg.getDeviceId(), DataConstants.CLIENT_SCOPE, request.getAttributes().stream().collect(Collectors.toList()),
+        ctx.saveAttributes(msg.getTenantId(), msg.getDeviceId(), DataConstants.CLIENT_SCOPE, new ArrayList<>(request.getAttributes()) ,
                 new PluginCallback<Void>() {
                     @Override
                     public void onSuccess(PluginContext ctx, Void value) {
                         ctx.reply(new ResponsePluginToRuleMsg(msg.getUid(), tenantId, ruleId, BasicStatusCodeResponse.onSuccess(request.getMsgType(), request.getRequestId())));
 
+                        List<AttributeKvEntry> attributeKvEntries = ctx.convertAttributeKvEntriesToUnitSystemByTenantId(new ArrayList<>(request.getAttributes()), msg.getTenantId());
                         subscriptionManager.onLocalSubscriptionUpdate(ctx, msg.getDeviceId(), SubscriptionType.ATTRIBUTES, s -> {
                             List<TsKvEntry> subscriptionUpdate = new ArrayList<>();
-                            for (AttributeKvEntry kv : request.getAttributes()) {
+                            for (AttributeKvEntry kv : attributeKvEntries) {
                                 if (s.isAllKeys() || s.getKeyStates().containsKey(kv.getKey())) {
                                     subscriptionUpdate.add(new BasicTsKvEntry(kv.getLastUpdateTs(), kv));
                                 }

--- a/extensions-core/src/main/java/com/hashmapinc/server/extensions/core/plugin/telemetry/handlers/TelemetryRuleMsgHandler.java
+++ b/extensions-core/src/main/java/com/hashmapinc/server/extensions/core/plugin/telemetry/handlers/TelemetryRuleMsgHandler.java
@@ -114,7 +114,7 @@ public class TelemetryRuleMsgHandler extends DefaultRuleMsgHandler {
                 }
             }
         }
-        return ctx.convertTsKvEntriesToUnitSystemByTenantId(subscriptionUpdate, tenantId);
+        return ctx.convertKvEntriesToUnitSystemByTenantId(subscriptionUpdate, tenantId, BasicTsKvEntry.class);
     }
 
     @Override
@@ -152,7 +152,7 @@ public class TelemetryRuleMsgHandler extends DefaultRuleMsgHandler {
                 }
             }
         }
-        return ctx.convertDsKvEntriesToUnitSystemByTenantId(subscriptionUpdate, tenantId);
+        return ctx.convertKvEntriesToUnitSystemByTenantId(subscriptionUpdate, tenantId, BasicDsKvEntry.class);
     }
 
     @Override
@@ -164,7 +164,7 @@ public class TelemetryRuleMsgHandler extends DefaultRuleMsgHandler {
                     public void onSuccess(PluginContext ctx, Void value) {
                         ctx.reply(new ResponsePluginToRuleMsg(msg.getUid(), tenantId, ruleId, BasicStatusCodeResponse.onSuccess(request.getMsgType(), request.getRequestId())));
 
-                        List<AttributeKvEntry> attributeKvEntries = ctx.convertAttributeKvEntriesToUnitSystemByTenantId(new ArrayList<>(request.getAttributes()), msg.getTenantId());
+                        List<AttributeKvEntry> attributeKvEntries = ctx.convertKvEntriesToUnitSystemByTenantId(new ArrayList<>(request.getAttributes()), msg.getTenantId(), BaseAttributeKvEntry.class);
                         subscriptionManager.onLocalSubscriptionUpdate(ctx, msg.getDeviceId(), SubscriptionType.ATTRIBUTES, s -> {
                             List<TsKvEntry> subscriptionUpdate = new ArrayList<>();
                             for (AttributeKvEntry kv : attributeKvEntries) {

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <commons-collections4.version>4.2</commons-collections4.version>
         <snakeyaml.version>1.23</snakeyaml.version>
         <maven-install-plugin.version>2.5.1</maven-install-plugin.version>
-        <unit-converion.version>1.0.3</unit-converion.version>
+        <unit-converion.version>1.0.4</unit-converion.version>
         <poi-ooxml.version>4.0.1</poi-ooxml.version>
     </properties>
 

--- a/transport/mqtt/src/main/java/com/hashmapinc/server/transport/mqtt/sparkplug/SparkPlugDecodeService.java
+++ b/transport/mqtt/src/main/java/com/hashmapinc/server/transport/mqtt/sparkplug/SparkPlugDecodeService.java
@@ -115,13 +115,13 @@ public class SparkPlugDecodeService extends SparkPlugUtils {
     private void createKvEntryByDatatype(Metric metric, String unit, List<KvEntry> kvEntryList){
         MetricDataType dataType = metric.getDataType();
         if(dataType.getClazz() == String.class){
-            kvEntryList.add(new StringDataEntry(metric.getName(), unit, unit, (String) metric.getValue()));
+            kvEntryList.add(new StringDataEntry(metric.getName(), unit, (String) metric.getValue()));
         }else if(dataType.getClazz() == Long.class){
-            kvEntryList.add(new LongDataEntry(metric.getName(), unit, unit, (Long) metric.getValue()));
+            kvEntryList.add(new LongDataEntry(metric.getName(), unit, (Long) metric.getValue()));
         }else if(dataType.getClazz() == Double.class){
-            kvEntryList.add(new DoubleDataEntry(metric.getName(), unit,unit, (Double) metric.getValue()));
+            kvEntryList.add(new DoubleDataEntry(metric.getName(), unit, (Double) metric.getValue()));
         }else if(dataType.getClazz() == Boolean.class){
-            kvEntryList.add(new BooleanDataEntry(metric.getName(), unit, unit, (Boolean)metric.getValue()));
+            kvEntryList.add(new BooleanDataEntry(metric.getName(), unit, (Boolean)metric.getValue()));
         }
     }
 

--- a/transport/mqtt/src/main/java/com/hashmapinc/server/transport/mqtt/sparkplug/SparkPlugDecodeService.java
+++ b/transport/mqtt/src/main/java/com/hashmapinc/server/transport/mqtt/sparkplug/SparkPlugDecodeService.java
@@ -115,13 +115,13 @@ public class SparkPlugDecodeService extends SparkPlugUtils {
     private void createKvEntryByDatatype(Metric metric, String unit, List<KvEntry> kvEntryList){
         MetricDataType dataType = metric.getDataType();
         if(dataType.getClazz() == String.class){
-            kvEntryList.add(new StringDataEntry(metric.getName(), unit, (String) metric.getValue()));
+            kvEntryList.add(new StringDataEntry(metric.getName(), unit, unit, (String) metric.getValue()));
         }else if(dataType.getClazz() == Long.class){
-            kvEntryList.add(new LongDataEntry(metric.getName(), unit, (Long) metric.getValue()));
+            kvEntryList.add(new LongDataEntry(metric.getName(), unit, unit, (Long) metric.getValue()));
         }else if(dataType.getClazz() == Double.class){
-            kvEntryList.add(new DoubleDataEntry(metric.getName(), unit,(Double) metric.getValue()));
+            kvEntryList.add(new DoubleDataEntry(metric.getName(), unit,unit, (Double) metric.getValue()));
         }else if(dataType.getClazz() == Boolean.class){
-            kvEntryList.add(new BooleanDataEntry(metric.getName(), unit, (Boolean)metric.getValue()));
+            kvEntryList.add(new BooleanDataEntry(metric.getName(), unit, unit, (Boolean)metric.getValue()));
         }
     }
 

--- a/transport/mqtt/src/main/java/com/hashmapinc/server/transport/mqtt/sparkplug/SparkPlugDecodeService.java
+++ b/transport/mqtt/src/main/java/com/hashmapinc/server/transport/mqtt/sparkplug/SparkPlugDecodeService.java
@@ -119,7 +119,7 @@ public class SparkPlugDecodeService extends SparkPlugUtils {
         }else if(dataType.getClazz() == Long.class){
             kvEntryList.add(new LongDataEntry(metric.getName(), unit, (Long) metric.getValue()));
         }else if(dataType.getClazz() == Double.class){
-            kvEntryList.add(new DoubleDataEntry(metric.getName(), unit, (Double) metric.getValue()));
+            kvEntryList.add(new DoubleDataEntry(metric.getName(), unit,(Double) metric.getValue()));
         }else if(dataType.getClazz() == Boolean.class){
             kvEntryList.add(new BooleanDataEntry(metric.getName(), unit, (Boolean)metric.getValue()));
         }

--- a/ui/src/app/locale/locale.constant.js
+++ b/ui/src/app/locale/locale.constant.js
@@ -1846,9 +1846,9 @@ export default angular.module('tempus.locale', [])
                     "save-preferences-success":"Unit Preferences saved successfully",
                     "preferences":"Preferences",
                     "units":"Units",
-                    "si-metric-system" :"SI-Metric System",
-                    "imperials-units":"Imperials System",
-                    "us-customary-units":"US-Customary System"
+                    "metric-system" :"Metric Unit System",
+                    "english-system":"English Unit System",
+                    "canadian-system":"Canadian Unit System"
                 },
                 "signup": {
                     "activation-msg" : "An activation link has been sent to your register email address." ,
@@ -1872,7 +1872,6 @@ export default angular.module('tempus.locale', [])
                     "first-name": "First Name",
                     "sign-up": "Sign up to get your own personal account for Free !",
                     "emailSuccess": "Email is sent on your email id.Please check."
-
                 }
             }
         }

--- a/ui/src/app/preferences/preferences.tpl.html
+++ b/ui/src/app/preferences/preferences.tpl.html
@@ -28,10 +28,9 @@
             <v-pane-content class="pane-header">
                 <div>
                     <md-radio-group ng-model="vm.selectedUnit" >
-                        <md-radio-button value="SI" class="md-primary"> {{ 'preferences.si-metric-system' | translate }} </md-radio-button>
-                        <!--TODO : Remove these after having support for Imperial and US-Customary Unit System-->
-                        <!--<md-radio-button value="UK" class="md-primary"> {{ 'preferences.imperials-units' | translate }} </md-radio-button>
-                        <md-radio-button value="US" class="md-primary"> {{ 'preferences.us-customary-units' | translate }} </md-radio-button>-->
+                        <md-radio-button value="Metric" class="md-primary"> {{ 'preferences.metric-system' | translate }} </md-radio-button>
+                        <md-radio-button value="English" class="md-primary"> {{ 'preferences.english-system' | translate }} </md-radio-button>
+                        <md-radio-button value="Canadian" class="md-primary"> {{ 'preferences.canadian-system' | translate }} </md-radio-button>
                     </md-radio-group>
                 </div>
             </v-pane-content>


### PR DESCRIPTION
Card : #998 
1. Added support for English, Metric and Canadian Unit Systems.
2. Changed ts, ds and attribute kv Entry to save source unit.
3. Added functions for converting KvEntries according to tenant unit system preference.

Thank you for submitting a contribution to Tempus.

In order to streamline the review of the contribution please
ensure the following steps have been taken:

### For all changes:
- [x] Is there a Waffle ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with Tempus-XXXX where XXXX is the waffle number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically dev)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root Tempus folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] Have you added documentation for any UI or API related changes to the /docs folder

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
